### PR TITLE
feat: add MCP server for Asana archive with query layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -294,3 +294,4 @@ tags
 
 # Project-specific
 asana_export/
+asana_responses/

--- a/asana_mcp_schema.json
+++ b/asana_mcp_schema.json
@@ -1,0 +1,523 @@
+{
+  "name": "Asana:create_project_preview",
+  "description": "Generate a visual preview of a project structure before creation. Use anytime the user asks to create a project or draft a project. Use this when you want the user to review and confirm the project structure first.",
+  "parameters": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "properties": {
+      "project_name": {
+        "description": "Name of the project to create.",
+        "type": "string"
+      },
+      "sections": {
+        "description": "Users will give you a request to create a project with a certain purpose. Use your own knowledge of project management and the principles and guidance below to design the best project structure possible.\n\nJSON array of section objects. Each section must have:\n- sectionName (string): Name of the section.\n- tasks (array): Array of task objects.\n\nEach task object must have:\n- taskName (string): Name of the task.\n- description (string | null): Description of the task, or null if the task has no description. Defaults to null if not provided.\n- isComplete (boolean): Whether the task is completed. Defaults to false if not provided.\n- startDate (string | null): Start date of the task in YYYY-MM-DD format, or null if the task has no start date. If the start date is provided, the due date must also be provided. If both the start date and due date are provided, the due date must be greater than or equal to the start date. Defaults to null if not provided.\n- dueDate (string | null): Due date of the task in YYYY-MM-DD format, or null if the task has no due date. If both the start date and due date are provided, the due date must be greater than or equal to the start date. Defaults to null if not provided.\n- assignee (string | null): Assignee of the task, or null if the task is unassigned. This can be \"me\", an email, or a user GID chosen among those found using asana_get_workspace_users. Defaults to null if not provided.\n- priority (\"low\" | \"medium\" | \"high\" | null): Priority level of the task. Must be one of 'low', 'medium', 'high', or null. Defaults to null if not provided.\n\nThis is general guidance for creating good project structures. Follow these principles and guidance as closely as possible unless the user specifically asks you to do otherwise:\nCreate the project structure in the same language as the user's request.\n\n- Project should have >=4 sections.\n\n- Limit the number of tasks to no more than 5 tasks per section.\n\n- Limit sections up to 6.\n\n- Every section should have at least one task.\n\n- If the user does not specifically give you tasks they want to include in their project, make tasks for the project that are aligned with the project's purpose.\n\n- Only mark tasks as complete (isComplete: true) if the user specifically mentioned they already completed that work. Otherwise, all tasks should be incomplete (isComplete: false).\n\n- When adding dates to tasks, always provide BOTH startDate and dueDate together as a date range. Never provide only dueDate without startDate. Add date ranges to several tasks so they will be useful for timeline and calendar views when the project is created.\n\n- All dates must be in the future (today or later), never in the past.\n\n- Create logical, sequential timelines that make sense for the project's purpose. Tasks should progress in a meaningful order (e.g., beginner tasks before advanced tasks, setup tasks before execution tasks).\n\n- Dates should form a coherent timeline, not be randomly scattered.\n\n- Prefer including the 'priority' custom field for every task (one of 'low', 'medium', or 'high'), unless the user has specifically instructed you not to. This helps users organize their work by importance.\n\nExample:\n[\n  {\n    \"sectionName\": \"Backlog\",\n    \"tasks\": [\n      {\n        \"taskName\": \"Design homepage\",\n        \"description\": \"Create a modern and responsive homepage design\",\n        \"isComplete\": false,\n        \"startDate\": \"2025-01-10\",\n        \"dueDate\": \"2025-01-15\",\n        \"assignee\": \"123456789\",\n        \"priority\": \"high\"\n      },\n      {\n        \"taskName\": \"Write documentation\",\n        \"description\": null,\n        \"isComplete\": false,\n        \"startDate\": \"2025-01-15\",\n        \"dueDate\": \"2025-01-20\",\n        \"assignee\": \"987654321\",\n        \"priority\": \"medium\"\n      }\n    ]\n  },\n  {\n    \"sectionName\": \"In Progress\",\n    \"tasks\": [\n      {\n        \"taskName\": \"Implement API endpoints\",\n        \"description\": \"Build RESTful API endpoints for user management\",\n        \"isComplete\": false,\n        \"startDate\": \"2025-01-10\",\n        \"dueDate\": \"2025-01-25\",\n        \"assignee\": \"123456789\",\n        \"priority\": \"high\"\n      },\n      {\n        \"taskName\": \"Code review\",\n        \"description\": null,\n        \"isComplete\": false,\n        \"startDate\": \"2025-01-25\",\n        \"dueDate\": \"2025-01-30\",\n        \"assignee\": null,\n        \"priority\": \"medium\"\n      },\n      {\n        \"taskName\": \"Deploy to staging\",\n        \"description\": \"Deploy the latest version to staging environment\",\n        \"isComplete\": false,\n        \"startDate\": \"2025-01-05\",\n        \"dueDate\": \"2025-01-08\",\n        \"assignee\": \"987654321\",\n        \"priority\": \"high\"\n      }\n    ]\n  }\n]",
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "sectionName": {
+              "description": "Name of the section.",
+              "type": "string"
+            },
+            "tasks": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "assignee": {
+                    "description": "Assignee of the task, or null if the task is unassigned. This can be \"me\", an email, or a user GID chosen among those found using asana_get_workspace_users. Defaults to null if not provided.",
+                    "type": ["string", "null"]
+                  },
+                  "description": {
+                    "description": "Description of the task, or null if the task has no description. Defaults to null if not provided.",
+                    "type": ["string", "null"]
+                  },
+                  "dueDate": {
+                    "anyOf": [{"pattern": "^\\d{4}-\\d{2}-\\d{2}$", "type": "string"}, {"type": "null"}],
+                    "description": "Due date of the task in YYYY-MM-DD format, or null if the task has no due date. If both the start date and due date are provided, the due date must be greater than or equal to the start date. Defaults to null if not provided."
+                  },
+                  "isComplete": {
+                    "description": "Whether the task is completed. Defaults to false if not provided.",
+                    "type": "boolean"
+                  },
+                  "priority": {
+                    "anyOf": [{"enum": ["low", "medium", "high"], "type": "string"}, {"type": "null"}],
+                    "description": "Priority level of the task. Must be one of 'low', 'medium', 'high', or null. Defaults to null if not provided."
+                  },
+                  "startDate": {
+                    "anyOf": [{"pattern": "^\\d{4}-\\d{2}-\\d{2}$", "type": "string"}, {"type": "null"}],
+                    "description": "Start date of the task in YYYY-MM-DD format, or null if the task has no start date. If the start date is provided, the due date must also be provided. If both the start date and due date are provided, the due date must be greater than or equal to the start date. Defaults to null if not provided."
+                  },
+                  "taskName": {
+                    "description": "Name of the task.",
+                    "type": "string"
+                  }
+                },
+                "required": ["taskName"],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": ["sectionName", "tasks"],
+          "type": "object"
+        },
+        "type": "array"
+      }
+    },
+    "required": ["project_name", "sections"],
+    "type": "object"
+  }
+},
+{
+  "name": "Asana:create_task_preview",
+  "description": "Generate a visual preview of a task before creation. Use anytime the user asks to create a task or draft a task. Use this when you want the user to review and confirm the task details first.",
+  "parameters": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "properties": {
+      "assignee": {
+        "description": "Assignee of the task, or null if the task is unassigned. This can be \"me\", an email, or a user GID chosen among those found using asana_get_workspace_users. Defaults to null if not provided.",
+        "type": ["string", "null"]
+      },
+      "description": {
+        "description": "Description of the task, or null if the task has no description. Defaults to null if not provided.",
+        "type": ["string", "null"]
+      },
+      "dueDate": {
+        "anyOf": [{"pattern": "^\\d{4}-\\d{2}-\\d{2}$", "type": "string"}, {"type": "null"}],
+        "description": "Due date of the task in YYYY-MM-DD format, or null if the task has no due date. If both the start date and due date are provided, the due date must be greater than or equal to the start date. Defaults to null if not provided."
+      },
+      "isComplete": {
+        "description": "Whether the task is completed. Defaults to false if not provided.",
+        "type": "boolean"
+      },
+      "startDate": {
+        "anyOf": [{"pattern": "^\\d{4}-\\d{2}-\\d{2}$", "type": "string"}, {"type": "null"}],
+        "description": "Start date of the task in YYYY-MM-DD format, or null if the task has no start date. If the start date is provided, the due date must also be provided. If both the start date and due date are provided, the due date must be greater than or equal to the start date. Defaults to null if not provided."
+      },
+      "taskName": {
+        "description": "Name of the task.",
+        "type": "string"
+      }
+    },
+    "required": ["taskName"],
+    "type": "object"
+  }
+},
+{
+  "name": "Asana:get_items_for_portfolio",
+  "description": "List projects, goals, and other items in a portfolio. Returns item names, IDs, and types. Use for portfolio content exploration and management. Supports pagination for portfolios with many items.",
+  "parameters": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "properties": {
+      "limit": {
+        "description": "Results per page (1-100)",
+        "maximum": 100,
+        "minimum": 1,
+        "type": "number"
+      },
+      "offset": {
+        "description": "Pagination offset token",
+        "type": "string"
+      },
+      "opt_fields": {
+        "description": "Comma-separated list of optional fields to include in the response",
+        "type": "string"
+      },
+      "portfolio_gid": {
+        "description": "Globally unique identifier for the portfolio",
+        "type": "string"
+      }
+    },
+    "required": ["portfolio_gid"],
+    "type": "object"
+  }
+},
+{
+  "name": "Asana:get_portfolio",
+  "description": "Get detailed portfolio data by ID including name, owner, and projects. Use after finding portfolio ID via typeahead. Returns complete portfolio configuration. Essential for understanding portfolio context and content.",
+  "parameters": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "properties": {
+      "opt_fields": {
+        "description": "Comma-separated list of optional fields to include in the response",
+        "type": "string"
+      },
+      "portfolio_gid": {
+        "description": "Globally unique identifier for the portfolio",
+        "type": "string"
+      }
+    },
+    "required": ["portfolio_gid"],
+    "type": "object"
+  }
+},
+{
+  "name": "Asana:get_portfolios",
+  "description": "List portfolios in workspace owned by the current user. REQUIRES workspace parameter. Returns portfolio names and IDs for portfolios you own. Use for portfolio discovery and management. Supports pagination for workspaces with many portfolios.",
+  "parameters": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "properties": {
+      "limit": {
+        "description": "Results per page (1-100)",
+        "maximum": 100,
+        "minimum": 1,
+        "type": "number"
+      },
+      "offset": {
+        "description": "Pagination offset token",
+        "type": "string"
+      },
+      "opt_fields": {
+        "description": "Comma-separated list of optional fields to include in the response",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+},
+{
+  "name": "Asana:get_project",
+  "description": "Get detailed project data including name, description, owner, members, custom fields, and settings. Use after finding project ID via typeahead. Returns complete project configuration needed for task operations. Specify opt_fields for custom fields data.",
+  "parameters": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "properties": {
+      "opt_fields": {
+        "description": "Comma-separated list of optional fields to include in the response.",
+        "type": "string"
+      },
+      "project_id": {
+        "description": "Globally unique identifier for the project.",
+        "type": "string"
+      }
+    },
+    "required": ["project_id"],
+    "type": "object"
+  }
+},
+{
+  "name": "Asana:get_projects",
+  "description": "List projects filtered by workspace. Supports team, archived filters. Returns project names and IDs. Use for filtered project views and bulk operations.",
+  "parameters": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "properties": {
+      "archived": {
+        "default": false,
+        "description": "Include archived projects.",
+        "type": "boolean"
+      },
+      "limit": {
+        "description": "Number of projects to return per page (1-100).",
+        "maximum": 100,
+        "minimum": 1,
+        "type": "number"
+      },
+      "offset": {
+        "description": "Pagination offset token.",
+        "type": "string"
+      },
+      "opt_fields": {
+        "description": "Comma-separated list of optional fields to include in the response.",
+        "type": "string"
+      },
+      "team": {
+        "description": "Filter projects on team id",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+},
+{
+  "name": "Asana:get_status_overview",
+  "description": "Get status overview and progress reports for initiatives/projects. Use this tool as a standalone when users ask for: status updates, status reports, project status, work overview, progress overview, initiative status, identified blockers, or any status-related queries. This tool searches projects and portfolios, extracts tasks and status updates, and returns aggregated project details, tasks, and status information. IMPORTANT: Call this tool directly with keywords - do NOT call other search tools first. This tool handles all searching and aggregation internally.",
+  "parameters": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "properties": {
+      "keywords": {
+        "description": "Keywords to search for projects. Can be a single keyword (e.g., 'asana') or multiple comma-separated keywords (e.g., 'asana, chatgpt, integration'). The tool searches each keyword separately and combines results from all matching projects (OR logic - matches any keyword).",
+        "type": "string"
+      },
+      "opt_fields": {
+        "description": "Comma-separated list of optional fields to include in task data (e.g., 'name,notes,assignee,due_on,completed').",
+        "type": "string"
+      }
+    },
+    "required": ["keywords"],
+    "type": "object"
+  }
+},
+{
+  "name": "Asana:get_task",
+  "description": "Get full task details by ID. Returns name, description, assignee, due dates, custom fields, projects, dependencies. Essential before updating tasks. Use opt_fields for custom field values. Required for understanding task context.",
+  "parameters": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "properties": {
+      "opt_fields": {
+        "description": "Comma-separated list of optional fields to include in the response.",
+        "type": "string"
+      },
+      "task_id": {
+        "description": "Globally unique identifier for the task.",
+        "type": "string"
+      }
+    },
+    "required": ["task_id"],
+    "type": "object"
+  }
+},
+{
+  "name": "Asana:get_tasks",
+  "description": "List tasks filtered by context (workspace/project/tag/section/user list). One context required. Supports assignee, date filters. Returns task names and IDs. Use for filtered task views and bulk operations.",
+  "parameters": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "properties": {
+      "assignee": {
+        "description": "User identifier to assign the task to. Can be \"me\", an email, or a user GID.",
+        "type": "string"
+      },
+      "completed_since": {
+        "description": "Filter for tasks completed since this date in datetime format.",
+        "format": "date-time",
+        "type": "string"
+      },
+      "limit": {
+        "description": "Number of sections to return per page (1-100).",
+        "maximum": 100,
+        "minimum": 1,
+        "type": "number"
+      },
+      "modified_since": {
+        "description": "Filter for tasks modified since this date in datetime format.",
+        "format": "date-time",
+        "type": "string"
+      },
+      "offset": {
+        "description": "Pagination offset token.",
+        "type": "string"
+      },
+      "opt_fields": {
+        "description": "Comma-separated list of optional fields to include in the response.",
+        "type": "string"
+      },
+      "project": {
+        "description": "Globally unique identifier for the project.",
+        "type": "string"
+      },
+      "section": {
+        "description": "Globally unique identifier for the section.",
+        "type": "string"
+      },
+      "tag": {
+        "description": "The tag GID to retrieve tasks for",
+        "type": "string"
+      },
+      "user_task_list": {
+        "description": "Globally unique identifier for the user task list.",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+},
+{
+  "name": "Asana:get_user",
+  "description": "Get user details by ID, email, or \"me\". Returns name, email, workspaces. Use to find user IDs for task assignment. \"me\" returns authenticated user info. Essential before assigning tasks. When no user_id is provided, defaults to \"me\" (authenticated user) - equivalent to the former asana_get_user_info tool.",
+  "parameters": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "properties": {
+      "opt_fields": {
+        "description": "Comma-separated list of optional fields to include in the response.",
+        "type": "string"
+      },
+      "user_id": {
+        "description": "A string identifying a user. This can be 'me', an email, or the gid of a user. When omitted, defaults to 'me' (authenticated user).",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+},
+{
+  "name": "Asana:get_workspace_users",
+  "description": "Get all users in workspace. Returns compact users with names and IDs. Results are sorted alphabetically and limited to 2000. Prefer searching more narrowly, like by typeahead or team first instead of this.",
+  "parameters": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "properties": {
+      "offset": {
+        "description": "Pagination offset token from a previous request.",
+        "type": "string"
+      },
+      "opt_fields": {
+        "description": "Comma-separated list of optional fields to include in the response.",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+},
+{
+  "name": "Asana:search_objects",
+  "description": "Quick search across Asana objects. ALWAYS use this FIRST before specialized search. Returns most relevant items based on recency and usage. Faster than dedicated search tools for finding specific items. If the user is not specific about which objects to search, use the following priority order: project + task > portfolio > goal + others (user, team, tag, custom_field).",
+  "parameters": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "properties": {
+      "count": {
+        "description": "Number of results to return. Default is 20 if parameter is empty. Minimum 1, maximum 100.",
+        "maximum": 100,
+        "minimum": 1,
+        "type": "number"
+      },
+      "opt_fields": {
+        "description": "Comma-separated list of optional fields to include in the response.",
+        "type": "string"
+      },
+      "query": {
+        "description": "The search query. Can be empty to get default results for the resource type.",
+        "type": "string"
+      },
+      "resource_type": {
+        "description": "The type of resource to search for.",
+        "enum": ["custom_field", "goal", "project", "project_template", "portfolio", "tag", "task", "team", "user"],
+        "type": "string"
+      }
+    },
+    "required": ["resource_type"],
+    "type": "object"
+  }
+},
+{
+  "name": "Asana:search_tasks_preview",
+  "description": "Search for tasks in the workspace and render a preview of the results. Use when the user wants to explore and search for tasks in the workspace, such as when the user asks to 'show me my tasks' or 'show me tasks for the week'. All search filters are optional, but use at least one search filter to limit the results to a specific set of tasks. For example, use the 'completed' filter to show only completed tasks, or the 'start_on_before' filter to show tasks that started before a certain date. Combine filters to find tasks that match multiple criteria, such as 'show me tasks assigned to Sarah that are due after next Monday'. Use the 'text' filter as a freeform search term to find tasks that match the specified text (exactly) in the task name or description. After calling this tool, do not summarize, list, or mention specific task names in your response.",
+  "parameters": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "properties": {
+      "assignee_any": {
+        "description": "Filter to tasks with assignees matching any of the comma-separated list of user identifiers. User identifiers can be \"me\", an email, or a user GID chosen among those found using asana_get_workspace_users. For example, if the user specifies \"my tasks\", set assignee_any to \"me\". Leave blank to show tasks assigned to any user.",
+        "type": "string"
+      },
+      "completed": {
+        "description": "Filter to either completed or incomplete tasks only. Leave blank to show both completed and incomplete tasks. Prefer filtering to incomplete tasks only, EXCEPT when the user specifically and EXPLICITLY asks for completed tasks only, or both completed and incomplete tasks.",
+        "type": "boolean"
+      },
+      "completed_on_after": {
+        "description": "Filter to tasks completed after the specified date. Date must be in YYYY-MM-DD format. Leave blank to show tasks completed after any date, including incomplete tasks.",
+        "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+        "type": "string"
+      },
+      "completed_on_before": {
+        "description": "Filter to tasks completed before the specified date. Date must be in YYYY-MM-DD format. Leave blank to show tasks completed before any date, including incomplete tasks.",
+        "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+        "type": "string"
+      },
+      "created_by_any": {
+        "description": "Filter to tasks created by a user matching any of the comma-separated list of user identifiers. User identifiers can be \"me\", an email, or a user GID chosen among those found using asana_get_workspace_users. Leave blank to show tasks created by any user.",
+        "type": "string"
+      },
+      "created_on_after": {
+        "description": "Filter to tasks created after the specified date. Date must be in YYYY-MM-DD format. Leave blank to show tasks created after any date.",
+        "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+        "type": "string"
+      },
+      "created_on_before": {
+        "description": "Filter to tasks created before the specified date. Date must be in YYYY-MM-DD format. Leave blank to show tasks created before any date.",
+        "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+        "type": "string"
+      },
+      "due_on_after": {
+        "description": "Filter to tasks due after the specified date. Date must be in YYYY-MM-DD format. Leave blank to show tasks due after any date, including tasks with no due date.",
+        "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+        "type": "string"
+      },
+      "due_on_before": {
+        "description": "Filter to tasks due before the specified date. Date must be in YYYY-MM-DD format. Leave blank to show tasks due before any date, including tasks with no due date.",
+        "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+        "type": "string"
+      },
+      "followers_any": {
+        "description": "Filter to tasks followed by any of the comma-separated list of user identifiers. User identifiers can be \"me\", an email, or a user GID chosen among those found using asana_get_workspace_users. Leave blank to show tasks followed by any user.",
+        "type": "string"
+      },
+      "projects_any": {
+        "description": "Filter to tasks in any of the comma-separated list of project IDs (GIDs). Project IDs can be chosen among those found using asana_get_projects. Leave blank to show tasks in any project.",
+        "type": "string"
+      },
+      "start_on_after": {
+        "description": "Filter to tasks with a start date after the specified date. Date must be in YYYY-MM-DD format. Leave blank to show tasks with a start date after any date, including tasks with no start date.",
+        "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+        "type": "string"
+      },
+      "start_on_before": {
+        "description": "Filter to tasks with a start date before the specified date. Date must be in YYYY-MM-DD format. Leave blank to show tasks with a start date before any date, including tasks with no start date.",
+        "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+        "type": "string"
+      },
+      "text": {
+        "description": "Freeform text to search for in task names and descriptions.",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+},
+{
+  "name": "Asana:update_task",
+  "description": "Update existing task properties. Change name, notes, assignee, completion status, due dates, custom fields. Requires task ID. Returns updated task data. Use asana_get_task first to understand current state.",
+  "parameters": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "properties": {
+      "assignee": {
+        "description": "User identifier to assign the task to. Can be \"me\", an email, or a user GID.",
+        "type": "string"
+      },
+      "completed": {
+        "description": "Mark the task as completed.",
+        "type": "boolean"
+      },
+      "custom_fields": {
+        "description": "JSON string of custom fields in format: {\"field_gid\": \"value\"}.",
+        "type": "string"
+      },
+      "due_at": {
+        "description": "Due date and time in ISO 8601 format.",
+        "format": "date-time",
+        "type": "string"
+      },
+      "due_on": {
+        "description": "Due date in ISO 8601 format (YYYY-MM-DD).",
+        "format": "date",
+        "type": "string"
+      },
+      "html_notes": {
+        "description": "New task description in HTML format. You can create links to other asana objects with the following instructions: For <a> tags specifically, to make it easier to create @-mentions through the API, we only require that you provide the GID of the object you wish to reference. If you have access to that object, the API will automatically generate the appropriate href and other attributes for you. For example, to create a link to a task with GID \"123\", you can send the tag <a data-asana-gid=\"123\"/> which will then be expanded to <a href=\"https://app.asana.com/0/0/123/f\" data-asana-accessible=\"true\" data-asana-dynamic=\"true\" data-asana-type=\"task\" data-asana-gid=\"123\">Task Name</a>. You can also generate a link to a task in a specific project or tag by including a data-asana-project or data-asana-tag attribute in the <a> tag. All other attributes, as well as the contents of the tag, are ignored.\n\nTo keep the contents of your tag and make a custom vanity link, include the property data-asana-dynamic=\"false\" when setting the contents of the tag. You would send <a data-asana-gid=\"123\" data-asana-dynamic=\"false\">This is some custom text!</a> and receive <a data-asana-accessible=\"true\" data-asana-dynamic=\"false\" data-asana-type=\"task\" data-asana-gid=\"123\">This is some custom text!</a>\n\nIf you do not have access to the referenced object when you try to create a link, the API will not generate an href for you, but will instead look for an href you provide. This allows you to write back <a> tags unmodified even if you do not have access to the resource. If you do not have access to the referenced object and no href is provided, your request will be rejected with a 400 Bad Request error. Similarly, if you provide neither a GID nor a valid href, the request will be rejected with the same error. ",
+        "type": "string"
+      },
+      "name": {
+        "description": "New name for the task.",
+        "type": "string"
+      },
+      "notes": {
+        "description": "New task description and details.",
+        "type": "string"
+      },
+      "task_id": {
+        "description": "Globally unique identifier for the task to update.",
+        "type": "string"
+      }
+    },
+    "required": ["task_id"],
+    "type": "object"
+  }
+}

--- a/justfile
+++ b/justfile
@@ -151,6 +151,10 @@ changelog:
     uv run git-cliff -o CHANGELOG.md
     @echo "✅ CHANGELOG.md updated"
 
+# Install/update the CLI tool
+update:
+    uv run scripts/update.py
+
 # Update all dependencies to latest versions
 update-deps:
     @echo "📦 Updating dependencies..."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "asana",
     "loguru>=0.7.0",
     "mcp[cli]>=1.9.0",
+    "pydantic>=2.12.5",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,12 @@ requires-python = ">=3.13"
 dependencies = [
     "asana",
     "loguru>=0.7.0",
+    "mcp[cli]>=1.9.0",
 ]
 
 [project.scripts]
 asana-exporter = "asana_exporter.client:main"
+asana-mcp = "asana_exporter.mcp.server:run_mcp_server"
 
 [build-system]
 requires = ["hatchling", "uv-dynamic-versioning"]
@@ -99,6 +101,7 @@ unfixable = [
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 "src/asana_exporter/database/schema.py" = ["E501"]
+"src/asana_exporter/mcp/server.py" = ["RUF029", "D417"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/scripts/update.py
+++ b/scripts/update.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Update script for asana-exporter: installs CLI tool."""
+
+import subprocess
+import sys
+
+
+def run_update() -> int:
+    """Run the update workflow.
+
+    Returns:
+        int: Exit code (0 for success, non-zero for failure).
+    """
+    print("📦 Installing asana-exporter tool...")
+    result = subprocess.run(
+        ["uv", "tool", "install", ".", "--reinstall", "--force"],
+        capture_output=False,
+    )
+    if result.returncode != 0:
+        print("❌ Failed to install tool")
+        return 1
+
+    print("✅ Update complete!")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run_update())

--- a/searching-asana-db.md
+++ b/searching-asana-db.md
@@ -1,0 +1,60 @@
+# Searching the Asana SQLite Database
+
+## Database Location
+
+- Export data: `/home/thomas/.local/share/asana/` (15GB JSON)
+- SQLite DB: `/home/thomas/.local/share/asana/asana.db` (~940MB)
+- Build with: `python -m asana_exporter.client --to-sqlite --export-path /home/thomas/.local/share/asana`
+
+## Key Schema Facts
+
+- Stories `resource_subtype` for comments is `'comment_added'`, NOT `'comment'`. This tripped up the search badly — zero results until corrected.
+- FTS table `task_search_fts` columns: `task_name, task_notes, subtask_text, comment_text, assignee_name, project_name, task_gid` — note `task_gid` is UNINDEXED (stored but not searchable). No `gid` column directly.
+- `task_search_fts` is holistic: one row per top-level task, aggregating all subtask text and comments. Good for broad searches but coarse.
+
+## Search Strategy for Vague Queries
+
+When the user describes something conversationally ("the ticket where we talked about X"), the information could be in:
+1. Task name
+2. Task notes/description
+3. **Comments (stories)** — most likely place for casual mentions
+4. Subtask names/notes
+
+### What works
+
+1. **Start with FTS** for a quick broad sweep, but know it uses porter stemming — exact field names like `user_id` may not stem well.
+2. **Fall back to LIKE queries on stories** joined to tasks — this is where conversational mentions live. Critical: use `resource_subtype = 'comment_added'` for actual comments.
+3. **Search comments broadly** — the answer was in a comment on a ticket with a completely different title ("documentation: some fields should be required, not optional"). The ticket title gave no hint about "falcon writes user_id".
+4. **Cast a wide net on comments**: search for key nouns (`falcon`, `user_id`) without requiring verbs like "write"/"store". People paraphrase.
+
+### What didn't work / wasted time
+
+- Searching only task names and notes — the discussion was in comments.
+- Using `resource_subtype = 'comment'` — this matched zero rows because the actual value is `'comment_added'`.
+- Over-constraining with too many terms (`falcon AND user_id AND write`) — too specific for a casual mention.
+- FTS alone — the holistic `task_search_fts` aggregates comment text but ranking didn't surface this well because the comment was one of many on the task.
+
+### Recommended approach
+
+```sql
+-- Step 1: Quick FTS sweep
+SELECT task_gid, task_name, substr(comment_text, 1, 300)
+FROM task_search_fts
+WHERE task_search_fts MATCH 'falcon user_id'
+ORDER BY rank LIMIT 10;
+
+-- Step 2: Direct comment search (the money query)
+SELECT s.task_gid, t.name, t.project_name, s.created_by_name,
+       substr(s.text, 1, 600)
+FROM stories s
+JOIN tasks t ON s.task_gid = t.gid
+WHERE s.resource_subtype = 'comment_added'
+  AND lower(s.text) LIKE '%falcon%'
+  AND lower(s.text) LIKE '%user_id%'
+LIMIT 20;
+
+-- Step 3: Broaden if needed — drop one keyword or use shorter fragments
+-- e.g. just '%falcon%' AND '%user%'
+```
+
+The direct comment search (Step 2) is what found the answer. If done first with the correct `resource_subtype`, the search would have been much faster.

--- a/src/asana_exporter/client.py
+++ b/src/asana_exporter/client.py
@@ -683,8 +683,7 @@ class AsanaExtractor:
         except asana.rest.ApiException as e:
             if e.status == 402:
                 LOG.warning(
-                    "search_tasks_for_workspace requires premium, "
-                    "falling back to per-project sync"
+                    "search_tasks_for_workspace requires premium, falling back to per-project sync"
                 )
                 return None
             raise
@@ -700,8 +699,7 @@ class AsanaExtractor:
                     modified_by_project.setdefault(project_gid, set()).add(task_gid)
 
         LOG.info(
-            f"pre-flight: {len(results)} modified tasks across "
-            f"{len(modified_by_project)} projects"
+            f"pre-flight: {len(results)} modified tasks across {len(modified_by_project)} projects"
         )
         return modified_by_project
 
@@ -920,8 +918,7 @@ class AsanaExtractor:
             projects_to_sync = [p for p in projects if p["gid"] in changed_project_gids]
             if len(projects_to_sync) < len(projects):
                 LOG.info(
-                    f"pre-flight: syncing {len(projects_to_sync)}/{len(projects)} "
-                    f"changed projects"
+                    f"pre-flight: syncing {len(projects_to_sync)}/{len(projects)} changed projects"
                 )
         else:
             projects_to_sync = projects

--- a/src/asana_exporter/database/__init__.py
+++ b/src/asana_exporter/database/__init__.py
@@ -2,6 +2,15 @@ from asana_exporter.database.loader import (
     ImportStats,
     import_export_dir,
 )
+from asana_exporter.database.queries import (
+    get_project,
+    get_projects,
+    get_task,
+    get_tasks,
+    get_user,
+    search_objects,
+    search_tasks,
+)
 from asana_exporter.database.schema import (
     create_schema,
     get_metadata,

--- a/src/asana_exporter/database/queries.py
+++ b/src/asana_exporter/database/queries.py
@@ -1,0 +1,372 @@
+"""Query functions for the Asana archive SQLite database."""
+
+import json
+import sqlite3
+from typing import Any
+
+_JSON_COLUMNS = ("tags", "custom_fields", "dependencies", "dependents", "followers")
+
+
+def get_user(
+    conn: sqlite3.Connection,
+    *,
+    user_gid: str | None = None,
+    email: str | None = None,
+) -> dict[str, Any]:
+    """Look up a user by GID or email."""
+    if user_gid:
+        row = conn.execute("SELECT * FROM users WHERE gid = ?", (user_gid,)).fetchone()
+    elif email:
+        row = conn.execute("SELECT * FROM users WHERE email = ?", (email,)).fetchone()
+    else:
+        return {"error": "Provide either user_gid or email."}
+
+    if not row:
+        return {"error": "User not found."}
+
+    return dict(row)
+
+
+def get_project(
+    conn: sqlite3.Connection,
+    *,
+    project_gid: str,
+    include_sections: bool = True,
+) -> dict[str, Any]:
+    """Get project details by GID, optionally with sections."""
+    row = conn.execute("SELECT * FROM projects WHERE gid = ?", (project_gid,)).fetchone()
+    if not row:
+        return {"error": f"Project '{project_gid}' not found."}
+
+    result = dict(row)
+
+    if include_sections:
+        section_rows = conn.execute(
+            "SELECT * FROM sections WHERE project_gid = ? ORDER BY rowid",
+            (project_gid,),
+        ).fetchall()
+        result["sections"] = [dict(s) for s in section_rows]
+
+    return result
+
+
+def get_tasks(
+    conn: sqlite3.Connection,
+    *,
+    project_gid: str | None = None,
+    section_gid: str | None = None,
+    assignee_gid: str | None = None,
+    completed: bool | None = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """List tasks with optional filters and pagination."""
+    conditions: list[str] = []
+    params: list[Any] = []
+
+    if project_gid is not None:
+        conditions.append("project_gid = ?")
+        params.append(project_gid)
+    if section_gid is not None:
+        conditions.append("section_gid = ?")
+        params.append(section_gid)
+    if assignee_gid is not None:
+        conditions.append("assignee_gid = ?")
+        params.append(assignee_gid)
+    if completed is not None:
+        conditions.append("completed = ?")
+        params.append(int(completed))
+
+    where = f" WHERE {' AND '.join(conditions)}" if conditions else ""
+
+    total = conn.execute(f"SELECT COUNT(*) FROM tasks{where}", params).fetchone()[0]
+
+    rows = conn.execute(
+        f"SELECT * FROM tasks{where} ORDER BY created_at LIMIT ? OFFSET ?",
+        [*params, limit, offset],
+    ).fetchall()
+
+    return _paginated_result([_task_row_to_dict(r) for r in rows], total, limit, offset)
+
+
+def _paginated_result(
+    results: list[dict[str, Any]],
+    total: int,
+    limit: int,
+    offset: int,
+) -> dict[str, Any]:
+    """Build a standardized pagination envelope."""
+    output: dict[str, Any] = {
+        "results": results,
+        "count": len(results),
+        "total": total,
+        "has_more": offset + len(results) < total,
+    }
+    if output["has_more"]:
+        output["next_offset"] = offset + limit
+    return output
+
+
+def get_projects(
+    conn: sqlite3.Connection,
+    *,
+    team_gid: str | None = None,
+    archived: bool | None = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """List projects with optional filters and pagination."""
+    conditions: list[str] = []
+    params: list[Any] = []
+
+    if team_gid is not None:
+        conditions.append("team_gid = ?")
+        params.append(team_gid)
+    if archived is not None:
+        conditions.append("archived = ?")
+        params.append(int(archived))
+
+    where = f" WHERE {' AND '.join(conditions)}" if conditions else ""
+
+    total = conn.execute(f"SELECT COUNT(*) FROM projects{where}", params).fetchone()[0]
+
+    rows = conn.execute(
+        f"SELECT * FROM projects{where} ORDER BY name LIMIT ? OFFSET ?",
+        [*params, limit, offset],
+    ).fetchall()
+
+    return _paginated_result([dict(r) for r in rows], total, limit, offset)
+
+
+def _task_row_to_dict(row: sqlite3.Row) -> dict[str, Any]:
+    """Convert a task row to a dict, parsing JSON columns and stripping raw_json."""
+    d = dict(row)
+    for col in _JSON_COLUMNS:
+        if col in d and isinstance(d[col], str):
+            d[col] = json.loads(d[col])
+    d.pop("raw_json", None)
+    return d
+
+
+def get_task(
+    conn: sqlite3.Connection,
+    *,
+    task_gid: str,
+    include_subtasks: bool = False,
+    include_stories: bool = False,
+) -> dict[str, Any]:
+    """Get full task details by GID."""
+    row = conn.execute("SELECT * FROM tasks WHERE gid = ?", (task_gid,)).fetchone()
+    if not row:
+        return {"error": f"Task '{task_gid}' not found."}
+
+    result = _task_row_to_dict(row)
+
+    if include_subtasks:
+        subtask_rows = conn.execute(
+            "SELECT * FROM tasks WHERE parent_gid = ? ORDER BY created_at",
+            (task_gid,),
+        ).fetchall()
+        result["subtasks"] = [_task_row_to_dict(s) for s in subtask_rows]
+
+    if include_stories:
+        story_rows = conn.execute(
+            "SELECT * FROM stories WHERE task_gid = ? ORDER BY created_at",
+            (task_gid,),
+        ).fetchall()
+        result["stories"] = [dict(s) for s in story_rows]
+
+    return result
+
+
+def _prepare_fts_query(query: str) -> str:
+    """Convert user query to FTS5 query with prefix matching.
+
+    Words 3+ chars get * suffix for prefix matching. AND/OR/NOT preserved.
+    Quoted phrases preserved as-is.
+    """
+    import re
+
+    tokens: list[str] = []
+    parts = re.split(r'(".*?")', query)
+    for part in parts:
+        if part.startswith('"') and part.endswith('"'):
+            tokens.append(part)
+        else:
+            for word in part.split():
+                upper = word.upper()
+                if upper in ("AND", "OR", "NOT"):
+                    tokens.append(upper)
+                else:
+                    cleaned = re.sub(r"[^\w]", "", word, flags=re.UNICODE)
+                    if cleaned:
+                        if len(cleaned) >= 3:
+                            tokens.append(f"{cleaned}*")
+                        else:
+                            tokens.append(cleaned)
+    return " ".join(tokens)
+
+
+def search_tasks(
+    conn: sqlite3.Connection,
+    *,
+    query: str,
+    project_gid: str | None = None,
+    assignee: str | None = None,
+    completed: bool | None = None,
+    use_holistic: bool = False,
+    limit: int = 20,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """Search tasks using FTS5.
+
+    Uses tasks_fts for per-entity search, or task_search_fts for holistic
+    search (combines task + subtasks + comments into one document).
+    """
+    if not query.strip():
+        return {"error": "Query must not be empty."}
+
+    fts_query = _prepare_fts_query(query)
+    if not fts_query:
+        return {"error": "Query must contain searchable terms."}
+
+    if use_holistic:
+        return _search_holistic(conn, fts_query, project_gid, completed, limit, offset)
+    return _search_per_entity(conn, fts_query, project_gid, assignee, completed, limit, offset)
+
+
+def _search_per_entity(
+    conn: sqlite3.Connection,
+    fts_query: str,
+    project_gid: str | None,
+    assignee: str | None,
+    completed: bool | None,
+    limit: int,
+    offset: int,
+) -> dict[str, Any]:
+    """Search tasks_fts (per-entity: each task/subtask is a separate document)."""
+    conditions = ["tasks_fts MATCH ?"]
+    params: list[Any] = [fts_query]
+
+    if project_gid is not None:
+        conditions.append("t.project_gid = ?")
+        params.append(project_gid)
+    if assignee is not None:
+        conditions.append("(t.assignee_gid = ? OR t.assignee_name LIKE ?)")
+        params.extend([assignee, f"%{assignee}%"])
+    if completed is not None:
+        conditions.append("t.completed = ?")
+        params.append(int(completed))
+
+    where = " AND ".join(conditions)
+
+    count_sql = f"""
+        SELECT COUNT(*) FROM tasks_fts
+        JOIN tasks t ON t.rowid = tasks_fts.rowid
+        WHERE {where}
+    """
+    total = conn.execute(count_sql, params).fetchone()[0]
+
+    select_sql = f"""
+        SELECT t.*, snippet(tasks_fts, 0, '**', '**', '...', 32) as snippet
+        FROM tasks_fts
+        JOIN tasks t ON t.rowid = tasks_fts.rowid
+        WHERE {where}
+        ORDER BY rank
+        LIMIT ? OFFSET ?
+    """
+    rows = conn.execute(select_sql, [*params, limit, offset]).fetchall()
+
+    results = []
+    for row in rows:
+        d = _task_row_to_dict(row)
+        d["snippet"] = row["snippet"]
+        results.append(d)
+
+    return _paginated_result(results, total, limit, offset)
+
+
+def _search_holistic(
+    conn: sqlite3.Connection,
+    fts_query: str,
+    project_gid: str | None,
+    completed: bool | None,
+    limit: int,
+    offset: int,
+) -> dict[str, Any]:
+    """Search task_search_fts (holistic: task + subtasks + comments combined)."""
+    conditions = ["task_search_fts MATCH ?"]
+    params: list[Any] = [fts_query]
+
+    join_conditions: list[str] = []
+    if project_gid is not None:
+        join_conditions.append("t.project_gid = ?")
+        params.append(project_gid)
+    if completed is not None:
+        join_conditions.append("t.completed = ?")
+        params.append(int(completed))
+
+    where = " AND ".join(conditions)
+    join_where = f" AND {' AND '.join(join_conditions)}" if join_conditions else ""
+
+    count_sql = f"""
+        SELECT COUNT(*) FROM task_search_fts
+        JOIN tasks t ON t.gid = task_search_fts.task_gid
+        WHERE {where}{join_where}
+    """
+    total = conn.execute(count_sql, params).fetchone()[0]
+
+    select_sql = f"""
+        SELECT t.*, snippet(task_search_fts, 0, '**', '**', '...', 32) as snippet
+        FROM task_search_fts
+        JOIN tasks t ON t.gid = task_search_fts.task_gid
+        WHERE {where}{join_where}
+        ORDER BY rank
+        LIMIT ? OFFSET ?
+    """
+    rows = conn.execute(select_sql, [*params, limit, offset]).fetchall()
+
+    results = []
+    for row in rows:
+        d = _task_row_to_dict(row)
+        d["snippet"] = row["snippet"]
+        results.append(d)
+
+    return _paginated_result(results, total, limit, offset)
+
+
+_SEARCH_OBJECTS_TABLES: dict[str, tuple[str, str]] = {
+    "project": ("projects", "name"),
+    "task": ("tasks", "name"),
+    "user": ("users", "name"),
+    "team": ("teams", "name"),
+}
+
+
+def search_objects(
+    conn: sqlite3.Connection,
+    *,
+    query: str,
+    resource_type: str,
+    count: int = 20,
+) -> dict[str, Any]:
+    """Quick LIKE-based typeahead search across object types."""
+    if resource_type not in _SEARCH_OBJECTS_TABLES:
+        valid = ", ".join(sorted(_SEARCH_OBJECTS_TABLES))
+        return {"error": f"Invalid resource_type '{resource_type}'. Must be one of: {valid}"}
+
+    table, name_col = _SEARCH_OBJECTS_TABLES[resource_type]
+
+    if query.strip():
+        rows = conn.execute(
+            f"SELECT * FROM {table} WHERE {name_col} LIKE ? ORDER BY {name_col} LIMIT ?",
+            (f"%{query}%", count),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            f"SELECT * FROM {table} ORDER BY {name_col} LIMIT ?",
+            (count,),
+        ).fetchall()
+
+    results = [dict(r) for r in rows]
+    return {"results": results, "count": len(results)}

--- a/src/asana_exporter/database/schema.py
+++ b/src/asana_exporter/database/schema.py
@@ -330,7 +330,7 @@ def rebuild_task_search_fts(conn: sqlite3.Connection) -> int:
                 GROUP_CONCAT(s.text, X'0A') AS comment_text
             FROM stories s
             JOIN task_roots tr ON tr.gid = s.task_gid
-            WHERE s.resource_subtype = 'comment'
+            WHERE s.resource_subtype = 'comment_added'
             GROUP BY tr.root_gid
         ) comment_agg ON comment_agg.root_gid = t.gid
         WHERE t.parent_gid IS NULL

--- a/src/asana_exporter/mcp/formatters.py
+++ b/src/asana_exporter/mcp/formatters.py
@@ -1,0 +1,236 @@
+"""Response formatters to match the official Asana MCP response format."""
+
+from typing import Any
+
+_COMPACT_FIELDS = ("gid", "name", "permalink_url")
+
+# Scalar fields that can be copied directly from a task row.
+_TASK_SCALAR_FIELDS = frozenset({
+    "notes",
+    "html_notes",
+    "due_on",
+    "due_at",
+    "start_on",
+    "start_at",
+    "created_at",
+    "modified_at",
+    "completed_at",
+    "resource_subtype",
+    "num_likes",
+    "num_subtasks",
+})
+
+# Scalar fields that can be copied directly from a project row.
+_PROJECT_SCALAR_FIELDS = frozenset({
+    "description",
+    "created_at",
+    "modified_at",
+    "due_date",
+})
+
+# Fields stored as int 0/1 in DB but should be bool in responses.
+_BOOL_FIELDS = frozenset({"completed", "archived"})
+
+# Nested object mappings: opt_field name -> (gid_column, name_column).
+# When gid_column is null/empty, the nested object is null.
+_TASK_NESTED_FIELDS: dict[str, tuple[str, str]] = {
+    "assignee": ("assignee_gid", "assignee_name"),
+    "parent": ("parent_gid", "parent_name"),
+    "team": ("team_gid", "team_name"),
+    "section": ("section_gid", "section_name"),
+}
+
+_PROJECT_NESTED_FIELDS: dict[str, tuple[str, str]] = {
+    "team": ("team_gid", "team_name"),
+    "owner": ("owner_gid", ""),  # name requires lookup
+}
+
+
+_FORMAT_FNS: dict[str, Any] = {}  # populated after function definitions
+
+
+def parse_opt_fields(opt_fields: str | None) -> set[str] | None:
+    """Parse a comma-separated opt_fields string into a set of field names."""
+    if opt_fields is None:
+        return None
+    return {f.strip() for f in opt_fields.split(",") if f.strip()}
+
+
+def _compact(row: dict[str, Any]) -> dict[str, Any]:
+    """Return compact representation: gid, name, permalink_url."""
+    return {k: row.get(k) for k in _COMPACT_FIELDS}
+
+
+def _add_scalar_fields(
+    result: dict[str, Any],
+    row: dict[str, Any],
+    opt_fields: set[str],
+    allowed: frozenset[str],
+) -> None:
+    """Add requested scalar fields from row to result."""
+    for field in opt_fields & allowed:
+        result[field] = row.get(field)
+    for field in opt_fields & _BOOL_FIELDS:
+        if field in row:
+            result[field] = bool(row[field])
+
+
+def _build_nested(
+    row: dict[str, Any],
+    gid_col: str,
+    name_col: str,
+) -> dict[str, str] | None:
+    """Build a nested {gid, name} object from flat DB columns."""
+    gid = row.get(gid_col)
+    if not gid:
+        return None
+    obj: dict[str, str] = {"gid": gid}
+    if name_col:
+        name = row.get(name_col, "")
+        if name:
+            obj["name"] = name
+    return obj
+
+
+def _add_nested_fields(
+    result: dict[str, Any],
+    row: dict[str, Any],
+    opt_fields: set[str],
+    nested_map: dict[str, tuple[str, str]],
+) -> None:
+    """Add requested nested object fields to result."""
+    for field, (gid_col, name_col) in nested_map.items():
+        if field in opt_fields or f"{field}.name" in opt_fields:
+            result[field] = _build_nested(row, gid_col, name_col)
+
+
+_PASSTHROUGH_KEYS = ("subtasks", "stories", "snippet")
+
+
+def _compact_with_collections(row: dict[str, Any]) -> dict[str, Any]:
+    """Return compact representation, preserving sub-collections like stories/subtasks."""
+    result = _compact(row)
+    for key in _PASSTHROUGH_KEYS:
+        if key in row:
+            result[key] = row[key]
+    return result
+
+
+def format_task(
+    row: dict[str, Any],
+    *,
+    opt_fields: set[str] | None = None,
+) -> dict[str, Any]:
+    """Format a task row for MCP response."""
+    if opt_fields is None:
+        return _compact_with_collections(row)
+    result = _compact(row)
+    _add_scalar_fields(result, row, opt_fields, _TASK_SCALAR_FIELDS)
+    _add_nested_fields(result, row, opt_fields, _TASK_NESTED_FIELDS)
+    # Projects: build from row's project_gid/project_name
+    if "projects" in opt_fields or "projects.name" in opt_fields:
+        pgid = row.get("project_gid")
+        if pgid:
+            result["projects"] = [{"gid": pgid, "name": row.get("project_name", "")}]
+        else:
+            result["projects"] = []
+    # Tags: convert string list to name objects
+    if "tags" in opt_fields or "tags.name" in opt_fields:
+        tags = row.get("tags", [])
+        result["tags"] = [{"name": t} for t in tags] if tags else []
+    # Pass through search snippets and sub-collections (subtasks/stories)
+    for key in _PASSTHROUGH_KEYS:
+        if key in row:
+            result[key] = row[key]
+    return result
+
+
+def format_project(
+    row: dict[str, Any],
+    *,
+    opt_fields: set[str] | None = None,
+) -> dict[str, Any]:
+    """Format a project row for MCP response."""
+    if opt_fields is None:
+        return _compact(row)
+    result = _compact(row)
+    _add_scalar_fields(result, row, opt_fields, _PROJECT_SCALAR_FIELDS)
+    _add_nested_fields(result, row, opt_fields, _PROJECT_NESTED_FIELDS)
+    # Official API uses "notes" but our DB stores "description"
+    if "notes" in opt_fields:
+        result["notes"] = row.get("description", "")
+    # Sections: include when requested
+    if ("sections" in opt_fields or "sections.name" in opt_fields) and "sections" in row:
+        sections = row["sections"]
+        result["sections"] = [{"gid": s["gid"], "name": s["name"]} for s in sections]
+    return result
+
+
+def format_user(
+    row: dict[str, Any],
+    *,
+    opt_fields: set[str] | None = None,
+) -> dict[str, Any]:
+    """Format a user row for MCP response."""
+    if opt_fields is None:
+        return _compact(row)
+    result = _compact(row)
+    if "email" in opt_fields:
+        result["email"] = row.get("email")
+    return result
+
+
+def _format_generic(
+    row: dict[str, Any],
+    *,
+    opt_fields: set[str] | None = None,
+) -> dict[str, Any]:
+    """Fallback formatter for resource types without specific formatting."""
+    return _compact(row)
+
+
+# Register format functions by resource type.
+_FORMAT_FNS.update({
+    "task": format_task,
+    "project": format_project,
+    "user": format_user,
+    "team": _format_generic,
+})
+
+
+def format_single(
+    data: dict[str, Any],
+    resource_type: str,
+    opt_fields: str | None,
+) -> dict[str, Any]:
+    """Wrap a single resource in the Asana response envelope."""
+    fields = parse_opt_fields(opt_fields)
+    fmt = _FORMAT_FNS.get(resource_type, _format_generic)
+    return {"data": fmt(data, opt_fields=fields)}
+
+
+def format_list(
+    query_result: dict[str, Any],
+    resource_type: str,
+    opt_fields: str | None,
+) -> dict[str, Any]:
+    """Wrap a paginated query result in the Asana response envelope."""
+    fields = parse_opt_fields(opt_fields)
+    fmt = _FORMAT_FNS.get(resource_type, _format_generic)
+    items = [fmt(row, opt_fields=fields) for row in query_result["results"]]
+    next_page = None
+    if query_result.get("has_more"):
+        next_page = {"offset": str(query_result["next_offset"])}
+    return {"data": items, "next_page": next_page}
+
+
+def format_search_objects(
+    query_result: dict[str, Any],
+    resource_type: str,
+    opt_fields: str | None,
+) -> dict[str, Any]:
+    """Wrap search_objects results in the Asana response envelope (no pagination)."""
+    fields = parse_opt_fields(opt_fields)
+    fmt = _FORMAT_FNS.get(resource_type, _format_generic)
+    items = [fmt(row, opt_fields=fields) for row in query_result["results"]]
+    return {"data": items}

--- a/src/asana_exporter/mcp/formatters.py
+++ b/src/asana_exporter/mcp/formatters.py
@@ -5,28 +5,32 @@ from typing import Any
 _COMPACT_FIELDS = ("gid", "name", "permalink_url")
 
 # Scalar fields that can be copied directly from a task row.
-_TASK_SCALAR_FIELDS = frozenset({
-    "notes",
-    "html_notes",
-    "due_on",
-    "due_at",
-    "start_on",
-    "start_at",
-    "created_at",
-    "modified_at",
-    "completed_at",
-    "resource_subtype",
-    "num_likes",
-    "num_subtasks",
-})
+_TASK_SCALAR_FIELDS = frozenset(
+    {
+        "notes",
+        "html_notes",
+        "due_on",
+        "due_at",
+        "start_on",
+        "start_at",
+        "created_at",
+        "modified_at",
+        "completed_at",
+        "resource_subtype",
+        "num_likes",
+        "num_subtasks",
+    }
+)
 
 # Scalar fields that can be copied directly from a project row.
-_PROJECT_SCALAR_FIELDS = frozenset({
-    "description",
-    "created_at",
-    "modified_at",
-    "due_date",
-})
+_PROJECT_SCALAR_FIELDS = frozenset(
+    {
+        "description",
+        "created_at",
+        "modified_at",
+        "due_date",
+    }
+)
 
 # Fields stored as int 0/1 in DB but should be bool in responses.
 _BOOL_FIELDS = frozenset({"completed", "archived"})
@@ -190,12 +194,14 @@ def _format_generic(
 
 
 # Register format functions by resource type.
-_FORMAT_FNS.update({
-    "task": format_task,
-    "project": format_project,
-    "user": format_user,
-    "team": _format_generic,
-})
+_FORMAT_FNS.update(
+    {
+        "task": format_task,
+        "project": format_project,
+        "user": format_user,
+        "team": _format_generic,
+    }
+)
 
 
 def format_single(

--- a/src/asana_exporter/mcp/server.py
+++ b/src/asana_exporter/mcp/server.py
@@ -1,0 +1,219 @@
+"""MCP server exposing Asana archive search and query tools."""
+
+import os
+import sqlite3
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from mcp.server.fastmcp import Context, FastMCP
+from mcp.types import ToolAnnotations
+
+from asana_exporter.database.queries import (
+    get_project,
+    get_projects,
+    get_task,
+    get_tasks,
+    get_user,
+    search_objects,
+    search_tasks,
+)
+from asana_exporter.database.schema import migrate_schema
+
+_DEFAULT_DB_PATH = Path("asana_export") / "asana.db"
+_READ_ONLY = ToolAnnotations(readOnlyHint=True, destructiveHint=False)
+
+
+@dataclass
+class ServerContext:
+    """Shared resources for the MCP server lifetime."""
+
+    conn: sqlite3.Connection
+
+
+@asynccontextmanager
+async def server_lifespan(_server: FastMCP) -> AsyncIterator[ServerContext]:
+    """Open database on startup, close on shutdown."""
+    db_path_str = os.environ.get("ASANA_DB_PATH")
+    db_path = Path(db_path_str) if db_path_str else _DEFAULT_DB_PATH
+
+    if not db_path.exists():
+        msg = (
+            f"Database not found at {db_path}. "
+            "Run 'asana-exporter' first to export and import data, "
+            "or set ASANA_DB_PATH environment variable."
+        )
+        raise FileNotFoundError(msg)
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    migrate_schema(conn)
+
+    try:
+        yield ServerContext(conn=conn)
+    finally:
+        conn.close()
+
+
+mcp_server = FastMCP(
+    "asana-archive",
+    instructions="""\
+Search and browse an offline Asana archive (projects, tasks, users).
+
+## Recommended Workflow
+1. Use asana_search_tasks for full-text search across all tasks.
+2. Use asana_get_projects / asana_get_tasks for filtered listing.
+3. Use asana_get_task for full details on a specific task.
+4. Use asana_search_objects for quick typeahead across object types.
+
+## Tips
+- All data is from an offline SQLite archive. Data may not reflect
+  real-time changes in Asana.
+- Use use_holistic=true in search_tasks to also search subtask and
+  comment text (not just the task itself).
+- Pagination: when has_more is true, use next_offset in a follow-up call.
+""",
+    lifespan=server_lifespan,
+)
+
+
+def _ctx(mcp_ctx: Context) -> ServerContext:
+    return mcp_ctx.request_context.lifespan_context  # type: ignore[return-value]
+
+
+# ── MCP Tool Wrappers ────────────────────────────────────────────────────
+
+
+@mcp_server.tool(name="asana_search_tasks", annotations=_READ_ONLY)
+async def asana_search_tasks_tool(
+    ctx: Context,
+    query: str,
+    project_gid: str | None = None,
+    assignee: str | None = None,
+    completed: bool | None = None,
+    use_holistic: bool = False,
+    limit: int = 20,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """Full-text search across tasks. Searches name, notes, assignee, project, and tags.
+
+    Set use_holistic=true to also search subtask text and comment text.
+    """
+    return search_tasks(
+        _ctx(ctx).conn,
+        query=query,
+        project_gid=project_gid,
+        assignee=assignee,
+        completed=completed,
+        use_holistic=use_holistic,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@mcp_server.tool(name="asana_get_task", annotations=_READ_ONLY)
+async def asana_get_task_tool(
+    ctx: Context,
+    task_gid: str,
+    include_subtasks: bool = False,
+    include_stories: bool = False,
+) -> dict[str, Any]:
+    """Get full task details by GID. Optionally include subtasks and comments."""
+    return get_task(
+        _ctx(ctx).conn,
+        task_gid=task_gid,
+        include_subtasks=include_subtasks,
+        include_stories=include_stories,
+    )
+
+
+@mcp_server.tool(name="asana_get_tasks", annotations=_READ_ONLY)
+async def asana_get_tasks_tool(
+    ctx: Context,
+    project_gid: str | None = None,
+    section_gid: str | None = None,
+    assignee_gid: str | None = None,
+    completed: bool | None = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """List tasks with filters. Provide at least one filter (project, section, assignee)."""
+    return get_tasks(
+        _ctx(ctx).conn,
+        project_gid=project_gid,
+        section_gid=section_gid,
+        assignee_gid=assignee_gid,
+        completed=completed,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@mcp_server.tool(name="asana_get_project", annotations=_READ_ONLY)
+async def asana_get_project_tool(
+    ctx: Context,
+    project_gid: str,
+    include_sections: bool = True,
+) -> dict[str, Any]:
+    """Get project details by GID, including sections."""
+    return get_project(
+        _ctx(ctx).conn,
+        project_gid=project_gid,
+        include_sections=include_sections,
+    )
+
+
+@mcp_server.tool(name="asana_get_projects", annotations=_READ_ONLY)
+async def asana_get_projects_tool(
+    ctx: Context,
+    team_gid: str | None = None,
+    archived: bool | None = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """List projects with optional team and archived filters."""
+    return get_projects(
+        _ctx(ctx).conn,
+        team_gid=team_gid,
+        archived=archived,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@mcp_server.tool(name="asana_get_user", annotations=_READ_ONLY)
+async def asana_get_user_tool(
+    ctx: Context,
+    user_gid: str | None = None,
+    email: str | None = None,
+) -> dict[str, Any]:
+    """Look up a user by GID or email."""
+    return get_user(
+        _ctx(ctx).conn,
+        user_gid=user_gid,
+        email=email,
+    )
+
+
+@mcp_server.tool(name="asana_search_objects", annotations=_READ_ONLY)
+async def asana_search_objects_tool(
+    ctx: Context,
+    query: str,
+    resource_type: str,
+    count: int = 20,
+) -> dict[str, Any]:
+    """Quick typeahead search. resource_type: project, task, user, or team."""
+    return search_objects(
+        _ctx(ctx).conn,
+        query=query,
+        resource_type=resource_type,
+        count=count,
+    )
+
+
+def run_mcp_server() -> None:
+    """Run the MCP server with stdio transport."""
+    mcp_server.run(transport="stdio")

--- a/src/asana_exporter/mcp/server.py
+++ b/src/asana_exporter/mcp/server.py
@@ -29,33 +29,21 @@ from asana_exporter.mcp.formatters import (
 )
 
 # Common parameter descriptions, reused across tools.
-_D_OPT_FIELDS = (
-    "Comma-separated list of optional fields to include."
-)
+_D_OPT_FIELDS = "Comma-separated list of optional fields to include."
 _D_LIMIT = "Results per page (1-100)."
 _D_OFFSET = "Pagination offset from a previous next_page."
 _D_PROJECT = "Globally unique identifier for the project."
 _D_SECTION = "Globally unique identifier for the section."
 _D_COMPLETED = "Filter to completed or incomplete tasks only."
 _D_TASK_ID = "Globally unique identifier for the task."
-_D_USER_ID = (
-    "Identifier for a user. Can be an email or a GID."
-)
-_D_QUERY = (
-    "Search query. Can be empty for default results."
-)
-_D_RESOURCE_TYPE = (
-    "Resource type to search: project, task, user, or team."
-)
+_D_USER_ID = "Identifier for a user. Can be an email or a GID."
+_D_QUERY = "Search query. Can be empty for default results."
+_D_RESOURCE_TYPE = "Resource type to search: project, task, user, or team."
 _D_COUNT = "Number of results to return (1-100)."
 _D_ASSIGNEE = "User GID to filter tasks by assignee."
-_D_HOLISTIC = (
-    "Also search subtask and comment text."
-)
+_D_HOLISTIC = "Also search subtask and comment text."
 _D_SUBTASKS = "Include the task's subtasks in the response."
-_D_STORIES = (
-    "Include comments and activity stories for the task."
-)
+_D_STORIES = "Include comments and activity stories for the task."
 
 _DEFAULT_DB_PATH = Path.home() / ".local" / "share" / "asana" / "asana.db"
 _READ_ONLY = ToolAnnotations(readOnlyHint=True, destructiveHint=False)

--- a/src/asana_exporter/mcp/server.py
+++ b/src/asana_exporter/mcp/server.py
@@ -22,7 +22,7 @@ from asana_exporter.database.queries import (
 )
 from asana_exporter.database.schema import migrate_schema
 
-_DEFAULT_DB_PATH = Path("asana_export") / "asana.db"
+_DEFAULT_DB_PATH = Path.home() / ".local" / "share" / "asana" / "asana.db"
 _READ_ONLY = ToolAnnotations(readOnlyHint=True, destructiveHint=False)
 
 

--- a/src/asana_exporter/mcp/server.py
+++ b/src/asana_exporter/mcp/server.py
@@ -6,10 +6,11 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
+from pydantic import Field
 
 from asana_exporter.database.queries import (
     get_project,
@@ -21,6 +22,40 @@ from asana_exporter.database.queries import (
     search_tasks,
 )
 from asana_exporter.database.schema import migrate_schema
+from asana_exporter.mcp.formatters import (
+    format_list,
+    format_search_objects,
+    format_single,
+)
+
+# Common parameter descriptions, reused across tools.
+_D_OPT_FIELDS = (
+    "Comma-separated list of optional fields to include."
+)
+_D_LIMIT = "Results per page (1-100)."
+_D_OFFSET = "Pagination offset from a previous next_page."
+_D_PROJECT = "Globally unique identifier for the project."
+_D_SECTION = "Globally unique identifier for the section."
+_D_COMPLETED = "Filter to completed or incomplete tasks only."
+_D_TASK_ID = "Globally unique identifier for the task."
+_D_USER_ID = (
+    "Identifier for a user. Can be an email or a GID."
+)
+_D_QUERY = (
+    "Search query. Can be empty for default results."
+)
+_D_RESOURCE_TYPE = (
+    "Resource type to search: project, task, user, or team."
+)
+_D_COUNT = "Number of results to return (1-100)."
+_D_ASSIGNEE = "User GID to filter tasks by assignee."
+_D_HOLISTIC = (
+    "Also search subtask and comment text."
+)
+_D_SUBTASKS = "Include the task's subtasks in the response."
+_D_STORIES = (
+    "Include comments and activity stories for the task."
+)
 
 _DEFAULT_DB_PATH = Path.home() / ".local" / "share" / "asana" / "asana.db"
 _READ_ONLY = ToolAnnotations(readOnlyHint=True, destructiveHint=False)
@@ -62,19 +97,22 @@ mcp_server = FastMCP(
     "asana-archive",
     instructions="""\
 Search and browse an offline Asana archive (projects, tasks, users).
+Mirrors the official Asana MCP tool interface for compatibility.
 
 ## Recommended Workflow
-1. Use asana_search_tasks for full-text search across all tasks.
-2. Use asana_get_projects / asana_get_tasks for filtered listing.
-3. Use asana_get_task for full details on a specific task.
-4. Use asana_search_objects for quick typeahead across object types.
+1. Use search_objects for quick typeahead across object types.
+2. Use search_tasks for full-text search across all tasks.
+3. Use get_projects / get_tasks for filtered listing.
+4. Use get_task for full details on a specific task.
 
 ## Tips
 - All data is from an offline SQLite archive. Data may not reflect
   real-time changes in Asana.
+- Use opt_fields to request specific fields (e.g. "name,completed,assignee.name").
+  Without opt_fields, only compact data (gid, name, permalink_url) is returned.
 - Use use_holistic=true in search_tasks to also search subtask and
   comment text (not just the task itself).
-- Pagination: when has_more is true, use next_offset in a follow-up call.
+- Pagination: when next_page is not null, use its offset in a follow-up call.
 """,
     lifespan=server_lifespan,
 )
@@ -87,131 +125,210 @@ def _ctx(mcp_ctx: Context) -> ServerContext:
 # ── MCP Tool Wrappers ────────────────────────────────────────────────────
 
 
-@mcp_server.tool(name="asana_search_tasks", annotations=_READ_ONLY)
-async def asana_search_tasks_tool(
+@mcp_server.tool(
+    name="search_tasks",
+    description=(
+        "Full-text search across tasks. Searches name, notes,"
+        " assignee, project, and tags."
+        " Set use_holistic=true to also search subtask and"
+        " comment text."
+    ),
+    annotations=_READ_ONLY,
+)
+async def search_tasks_tool(
     ctx: Context,
-    query: str,
-    project_gid: str | None = None,
-    assignee: str | None = None,
-    completed: bool | None = None,
-    use_holistic: bool = False,
-    limit: int = 20,
-    offset: int = 0,
+    query: Annotated[str, Field(description=_D_QUERY)],
+    project: Annotated[str | None, Field(description=_D_PROJECT)] = None,
+    assignee: Annotated[str | None, Field(description=_D_ASSIGNEE)] = None,
+    completed: Annotated[bool | None, Field(description=_D_COMPLETED)] = None,
+    use_holistic: Annotated[bool, Field(description=_D_HOLISTIC)] = False,
+    opt_fields: Annotated[str | None, Field(description=_D_OPT_FIELDS)] = None,
+    limit: Annotated[int, Field(description=_D_LIMIT, ge=1, le=100)] = 20,
+    offset: Annotated[int, Field(description=_D_OFFSET)] = 0,
 ) -> dict[str, Any]:
-    """Full-text search across tasks. Searches name, notes, assignee, project, and tags.
-
-    Set use_holistic=true to also search subtask text and comment text.
-    """
-    return search_tasks(
+    result = search_tasks(
         _ctx(ctx).conn,
         query=query,
-        project_gid=project_gid,
+        project_gid=project,
         assignee=assignee,
         completed=completed,
         use_holistic=use_holistic,
         limit=limit,
         offset=offset,
     )
+    if "error" in result:
+        return {"error": result["error"]}
+    return format_list(result, "task", opt_fields)
 
 
-@mcp_server.tool(name="asana_get_task", annotations=_READ_ONLY)
-async def asana_get_task_tool(
+@mcp_server.tool(
+    name="get_task",
+    description=(
+        "Get full task details by ID. Returns name, notes,"
+        " assignee, due dates, projects, tags."
+        " Use opt_fields for specific fields."
+        " Set include_subtasks or include_stories for"
+        " related data."
+    ),
+    annotations=_READ_ONLY,
+)
+async def get_task_tool(
     ctx: Context,
-    task_gid: str,
-    include_subtasks: bool = False,
-    include_stories: bool = False,
+    task_id: Annotated[str, Field(description=_D_TASK_ID)],
+    opt_fields: Annotated[str | None, Field(description=_D_OPT_FIELDS)] = None,
+    include_subtasks: Annotated[bool, Field(description=_D_SUBTASKS)] = False,
+    include_stories: Annotated[bool, Field(description=_D_STORIES)] = False,
 ) -> dict[str, Any]:
-    """Get full task details by GID. Optionally include subtasks and comments."""
-    return get_task(
+    result = get_task(
         _ctx(ctx).conn,
-        task_gid=task_gid,
+        task_gid=task_id,
         include_subtasks=include_subtasks,
         include_stories=include_stories,
     )
+    if "error" in result:
+        return {"error": result["error"]}
+    return format_single(result, "task", opt_fields)
 
 
-@mcp_server.tool(name="asana_get_tasks", annotations=_READ_ONLY)
-async def asana_get_tasks_tool(
+@mcp_server.tool(
+    name="get_tasks",
+    description=(
+        "List tasks filtered by project, section, or assignee."
+        " At least one filter required."
+        " Returns task names and IDs."
+        " Use for browsing project contents."
+    ),
+    annotations=_READ_ONLY,
+)
+async def get_tasks_tool(
     ctx: Context,
-    project_gid: str | None = None,
-    section_gid: str | None = None,
-    assignee_gid: str | None = None,
-    completed: bool | None = None,
-    limit: int = 20,
-    offset: int = 0,
+    project: Annotated[str | None, Field(description=_D_PROJECT)] = None,
+    section: Annotated[str | None, Field(description=_D_SECTION)] = None,
+    assignee: Annotated[str | None, Field(description=_D_ASSIGNEE)] = None,
+    completed: Annotated[bool | None, Field(description=_D_COMPLETED)] = None,
+    opt_fields: Annotated[str | None, Field(description=_D_OPT_FIELDS)] = None,
+    limit: Annotated[int, Field(description=_D_LIMIT, ge=1, le=100)] = 20,
+    offset: Annotated[int, Field(description=_D_OFFSET)] = 0,
 ) -> dict[str, Any]:
-    """List tasks with filters. Provide at least one filter (project, section, assignee)."""
-    return get_tasks(
+    result = get_tasks(
         _ctx(ctx).conn,
-        project_gid=project_gid,
-        section_gid=section_gid,
-        assignee_gid=assignee_gid,
+        project_gid=project,
+        section_gid=section,
+        assignee_gid=assignee,
         completed=completed,
         limit=limit,
         offset=offset,
     )
+    if "error" in result:
+        return {"error": result["error"]}
+    return format_list(result, "task", opt_fields)
 
 
-@mcp_server.tool(name="asana_get_project", annotations=_READ_ONLY)
-async def asana_get_project_tool(
+@mcp_server.tool(
+    name="get_project",
+    description=(
+        "Get detailed project data by ID including name,"
+        " description, owner, team, and sections."
+        " Use after finding project ID via search_objects."
+        " Specify opt_fields for additional details."
+    ),
+    annotations=_READ_ONLY,
+)
+async def get_project_tool(
     ctx: Context,
-    project_gid: str,
-    include_sections: bool = True,
+    project_id: Annotated[str, Field(description=_D_PROJECT)],
+    opt_fields: Annotated[str | None, Field(description=_D_OPT_FIELDS)] = None,
 ) -> dict[str, Any]:
-    """Get project details by GID, including sections."""
-    return get_project(
+    include_sections = opt_fields is not None and "sections" in opt_fields
+    result = get_project(
         _ctx(ctx).conn,
-        project_gid=project_gid,
+        project_gid=project_id,
         include_sections=include_sections,
     )
+    if "error" in result:
+        return {"error": result["error"]}
+    return format_single(result, "project", opt_fields)
 
 
-@mcp_server.tool(name="asana_get_projects", annotations=_READ_ONLY)
-async def asana_get_projects_tool(
+@mcp_server.tool(
+    name="get_projects",
+    description=(
+        "List projects with optional team and archived filters."
+        " Returns project names and IDs."
+        " Use for finding project GIDs."
+    ),
+    annotations=_READ_ONLY,
+)
+async def get_projects_tool(
     ctx: Context,
-    team_gid: str | None = None,
-    archived: bool | None = None,
-    limit: int = 20,
-    offset: int = 0,
+    team: Annotated[str | None, Field(description="Filter by team GID.")] = None,
+    archived: Annotated[bool | None, Field(description="Include archived projects.")] = None,
+    opt_fields: Annotated[str | None, Field(description=_D_OPT_FIELDS)] = None,
+    limit: Annotated[int, Field(description=_D_LIMIT, ge=1, le=100)] = 20,
+    offset: Annotated[int, Field(description=_D_OFFSET)] = 0,
 ) -> dict[str, Any]:
-    """List projects with optional team and archived filters."""
-    return get_projects(
+    result = get_projects(
         _ctx(ctx).conn,
-        team_gid=team_gid,
+        team_gid=team,
         archived=archived,
         limit=limit,
         offset=offset,
     )
+    if "error" in result:
+        return {"error": result["error"]}
+    return format_list(result, "project", opt_fields)
 
 
-@mcp_server.tool(name="asana_get_user", annotations=_READ_ONLY)
-async def asana_get_user_tool(
+@mcp_server.tool(
+    name="get_user",
+    description=(
+        "Get user details by GID or email."
+        " Returns name and email."
+        " Use to find user IDs for filtering tasks by assignee."
+    ),
+    annotations=_READ_ONLY,
+)
+async def get_user_tool(
     ctx: Context,
-    user_gid: str | None = None,
-    email: str | None = None,
+    user_id: Annotated[str | None, Field(description=_D_USER_ID)] = None,
+    opt_fields: Annotated[str | None, Field(description=_D_OPT_FIELDS)] = None,
 ) -> dict[str, Any]:
-    """Look up a user by GID or email."""
-    return get_user(
-        _ctx(ctx).conn,
-        user_gid=user_gid,
-        email=email,
-    )
+    conn = _ctx(ctx).conn
+    if user_id and "@" in user_id:
+        result = get_user(conn, email=user_id)
+    else:
+        result = get_user(conn, user_gid=user_id)
+    if "error" in result:
+        return {"error": result["error"]}
+    return format_single(result, "user", opt_fields)
 
 
-@mcp_server.tool(name="asana_search_objects", annotations=_READ_ONLY)
-async def asana_search_objects_tool(
+@mcp_server.tool(
+    name="search_objects",
+    description=(
+        "Quick search across Asana objects by name."
+        " Use this first before specialized search tools."
+        " Faster than search_tasks for finding specific"
+        " items by name."
+    ),
+    annotations=_READ_ONLY,
+)
+async def search_objects_tool(
     ctx: Context,
-    query: str,
-    resource_type: str,
-    count: int = 20,
+    query: Annotated[str, Field(description=_D_QUERY)],
+    resource_type: Annotated[str, Field(description=_D_RESOURCE_TYPE)],
+    count: Annotated[int, Field(description=_D_COUNT, ge=1, le=100)] = 20,
+    opt_fields: Annotated[str | None, Field(description=_D_OPT_FIELDS)] = None,
 ) -> dict[str, Any]:
-    """Quick typeahead search. resource_type: project, task, user, or team."""
-    return search_objects(
+    result = search_objects(
         _ctx(ctx).conn,
         query=query,
         resource_type=resource_type,
         count=count,
     )
+    if "error" in result:
+        return {"error": result["error"]}
+    return format_search_objects(result, resource_type, opt_fields)
 
 
 def run_mcp_server() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,6 +79,11 @@ def populated_db(db: sqlite3.Connection, tmp_path: Path) -> sqlite3.Connection:
         section_gid="sec2", section_name="In Progress",
         due_on="2024-03-01",
     )
+    t7 = make_task(
+        "t7", "Rename user_id to account_id",
+        project_gid="proj1", project_name="Backend API",
+        section_gid="sec2", section_name="In Progress",
+    )
 
     subtask = make_task(
         "st1", "Reproduce on Android",
@@ -90,7 +95,7 @@ def populated_db(db: sqlite3.Connection, tmp_path: Path) -> sqlite3.Connection:
     comment = make_story("s1", "Found the root cause - session token expires")
 
     tasks_map: dict[tuple[str, str], list[dict[str, Any]]] = {
-        ("team1", "proj1"): [t1, t2, t3, t6],
+        ("team1", "proj1"): [t1, t2, t3, t6, t7],
         ("team1", "proj2"): [t4],
         ("team2", "proj3"): [t5],
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,110 @@
+"""Shared test fixtures."""
+
+import sqlite3
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from asana_exporter.database.loader import import_export_dir
+from asana_exporter.database.schema import create_schema, rebuild_task_search_fts
+from tests.factories import build_export_tree, make_story, make_task
+
+
+@pytest.fixture
+def db() -> Generator[sqlite3.Connection]:
+    """In-memory SQLite connection with schema."""
+    conn = sqlite3.connect(":memory:")
+    conn.execute("PRAGMA foreign_keys = ON")
+    create_schema(conn)
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def populated_db(db: sqlite3.Connection, tmp_path: Path) -> sqlite3.Connection:
+    """In-memory DB populated with realistic Asana data for query testing."""
+    teams = [
+        {"gid": "team1", "name": "Engineering"},
+        {"gid": "team2", "name": "Design"},
+    ]
+    projects: dict[str, list[dict[str, Any]]] = {
+        "team1": [
+            {"gid": "proj1", "name": "Backend API"},
+            {"gid": "proj2", "name": "Frontend App"},
+        ],
+        "team2": [
+            {"gid": "proj3", "name": "Brand Guide"},
+        ],
+    }
+
+    t1 = make_task(
+        "t1", "Fix login bug",
+        project_gid="proj1", project_name="Backend API",
+        section_gid="sec1", section_name="To Do",
+        assignee={"gid": "user1", "name": "Alice", "email": "alice@example.com"},
+        notes="Login fails on mobile",
+        due_on="2024-02-01",
+    )
+    t2 = make_task(
+        "t2", "Add API rate limiting",
+        project_gid="proj1", project_name="Backend API",
+        section_gid="sec2", section_name="In Progress",
+        assignee={"gid": "user2", "name": "Bob", "email": "bob@example.com"},
+    )
+    t3 = make_task(
+        "t3", "Write API docs",
+        project_gid="proj1", project_name="Backend API",
+        section_gid="sec3", section_name="Done",
+        assignee={"gid": "user1", "name": "Alice", "email": "alice@example.com"},
+        completed=True,
+    )
+    t4 = make_task(
+        "t4", "Redesign dashboard",
+        project_gid="proj2", project_name="Frontend App",
+        section_gid="sec1", section_name="To Do",
+        assignee={"gid": "user2", "name": "Bob", "email": "bob@example.com"},
+        notes="Use new component library",
+    )
+    t5 = make_task(
+        "t5", "Update color palette",
+        project_gid="proj3", project_name="Brand Guide",
+        section_gid="sec4", section_name="Research",
+        assignee={"gid": "user1", "name": "Alice", "email": "alice@example.com"},
+    )
+    t6 = make_task(
+        "t6", "Deploy v2.0",
+        project_gid="proj1", project_name="Backend API",
+        section_gid="sec2", section_name="In Progress",
+        due_on="2024-03-01",
+    )
+
+    subtask = make_task(
+        "st1", "Reproduce on Android",
+        project_gid="proj1", project_name="Backend API",
+        section_gid="sec1", section_name="To Do",
+        assignee={"gid": "user2", "name": "Bob", "email": "bob@example.com"},
+    )
+
+    comment = make_story("s1", "Found the root cause - session token expires")
+
+    tasks_map: dict[tuple[str, str], list[dict[str, Any]]] = {
+        ("team1", "proj1"): [t1, t2, t3, t6],
+        ("team1", "proj2"): [t4],
+        ("team2", "proj3"): [t5],
+    }
+
+    build_export_tree(
+        str(tmp_path),
+        teams=teams,
+        projects=projects,
+        tasks=tasks_map,
+        stories={"t1": [comment]},
+        subtasks={"t1": [(subtask, [])]},
+    )
+
+    import_export_dir(db, str(tmp_path))
+    rebuild_task_search_fts(db)
+    db.row_factory = sqlite3.Row
+    return db

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,55 +40,79 @@ def populated_db(db: sqlite3.Connection, tmp_path: Path) -> sqlite3.Connection:
     }
 
     t1 = make_task(
-        "t1", "Fix login bug",
-        project_gid="proj1", project_name="Backend API",
-        section_gid="sec1", section_name="To Do",
+        "t1",
+        "Fix login bug",
+        project_gid="proj1",
+        project_name="Backend API",
+        section_gid="sec1",
+        section_name="To Do",
         assignee={"gid": "user1", "name": "Alice", "email": "alice@example.com"},
         notes="Login fails on mobile",
         due_on="2024-02-01",
     )
     t2 = make_task(
-        "t2", "Add API rate limiting",
-        project_gid="proj1", project_name="Backend API",
-        section_gid="sec2", section_name="In Progress",
+        "t2",
+        "Add API rate limiting",
+        project_gid="proj1",
+        project_name="Backend API",
+        section_gid="sec2",
+        section_name="In Progress",
         assignee={"gid": "user2", "name": "Bob", "email": "bob@example.com"},
     )
     t3 = make_task(
-        "t3", "Write API docs",
-        project_gid="proj1", project_name="Backend API",
-        section_gid="sec3", section_name="Done",
+        "t3",
+        "Write API docs",
+        project_gid="proj1",
+        project_name="Backend API",
+        section_gid="sec3",
+        section_name="Done",
         assignee={"gid": "user1", "name": "Alice", "email": "alice@example.com"},
         completed=True,
     )
     t4 = make_task(
-        "t4", "Redesign dashboard",
-        project_gid="proj2", project_name="Frontend App",
-        section_gid="sec1", section_name="To Do",
+        "t4",
+        "Redesign dashboard",
+        project_gid="proj2",
+        project_name="Frontend App",
+        section_gid="sec1",
+        section_name="To Do",
         assignee={"gid": "user2", "name": "Bob", "email": "bob@example.com"},
         notes="Use new component library",
     )
     t5 = make_task(
-        "t5", "Update color palette",
-        project_gid="proj3", project_name="Brand Guide",
-        section_gid="sec4", section_name="Research",
+        "t5",
+        "Update color palette",
+        project_gid="proj3",
+        project_name="Brand Guide",
+        section_gid="sec4",
+        section_name="Research",
         assignee={"gid": "user1", "name": "Alice", "email": "alice@example.com"},
     )
     t6 = make_task(
-        "t6", "Deploy v2.0",
-        project_gid="proj1", project_name="Backend API",
-        section_gid="sec2", section_name="In Progress",
+        "t6",
+        "Deploy v2.0",
+        project_gid="proj1",
+        project_name="Backend API",
+        section_gid="sec2",
+        section_name="In Progress",
         due_on="2024-03-01",
     )
     t7 = make_task(
-        "t7", "Rename user_id to account_id",
-        project_gid="proj1", project_name="Backend API",
-        section_gid="sec2", section_name="In Progress",
+        "t7",
+        "Rename user_id to account_id",
+        project_gid="proj1",
+        project_name="Backend API",
+        section_gid="sec2",
+        section_name="In Progress",
     )
 
     subtask = make_task(
-        "st1", "Reproduce on Android",
-        project_gid="proj1", project_name="Backend API",
-        section_gid="sec1", section_name="To Do",
+        "st1",
+        "Reproduce on Android",
+        project_gid="proj1",
+        project_name="Backend API",
+        section_gid="sec1",
+        section_name="To Do",
         assignee={"gid": "user2", "name": "Bob", "email": "bob@example.com"},
     )
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -58,7 +58,7 @@ def make_task(
     return task
 
 
-def make_story(gid: str, text: str, resource_subtype: str = "comment") -> dict[str, Any]:
+def make_story(gid: str, text: str, resource_subtype: str = "comment_added") -> dict[str, Any]:
     """Build a realistic Asana story dict."""
     return {
         "gid": gid,

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,156 @@
+"""Test data factory functions for building Asana export structures."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def write_json(path: str | Path, data: Any) -> None:
+    """Write data as JSON to a file, creating parent dirs."""
+    p = Path(path)
+    p.parent.mkdir(exist_ok=True, parents=True)
+    p.write_text(json.dumps(data))
+
+
+def make_task(
+    gid: str,
+    name: str,
+    project_gid: str = "proj1",
+    project_name: str = "Project One",
+    section_gid: str = "sec1",
+    section_name: str = "To Do",
+    assignee: dict[str, str] | None = None,
+    **extra: Any,
+) -> dict[str, Any]:
+    """Build a realistic Asana task dict."""
+    task: dict[str, Any] = {
+        "gid": gid,
+        "name": name,
+        "notes": extra.pop("notes", ""),
+        "html_notes": extra.pop("html_notes", ""),
+        "resource_subtype": "default_task",
+        "assignee": assignee,
+        "memberships": [
+            {
+                "project": {"gid": project_gid, "name": project_name},
+                "section": {"gid": section_gid, "name": section_name},
+            }
+        ],
+        "completed": extra.pop("completed", False),
+        "completed_at": None,
+        "completed_by": None,
+        "created_at": "2024-01-15T10:00:00.000Z",
+        "created_by": {"gid": "user1", "name": "Alice"},
+        "modified_at": "2024-01-16T12:00:00.000Z",
+        "due_on": None,
+        "due_at": None,
+        "start_on": None,
+        "start_at": None,
+        "num_likes": 0,
+        "permalink_url": f"https://app.asana.com/0/{project_gid}/{gid}",
+        "tags": extra.pop("tags", []),
+        "custom_fields": extra.pop("custom_fields", []),
+        "dependencies": [],
+        "dependents": [],
+        "followers": [{"gid": "user1", "name": "Alice"}],
+    }
+    task.update(extra)
+    return task
+
+
+def make_story(gid: str, text: str, resource_subtype: str = "comment") -> dict[str, Any]:
+    """Build a realistic Asana story dict."""
+    return {
+        "gid": gid,
+        "text": text,
+        "html_text": f"<p>{text}</p>",
+        "created_at": "2024-01-15T11:00:00.000Z",
+        "created_by": {"gid": "user2", "name": "Bob"},
+        "resource_subtype": resource_subtype,
+        "type": resource_subtype,
+    }
+
+
+def make_attachment(gid: str, name: str) -> dict[str, Any]:
+    """Build a realistic Asana attachment dict."""
+    return {
+        "gid": gid,
+        "name": name,
+        "file_name": name,
+        "host": "asana",
+        "size": 1024,
+        "created_at": "2024-01-15T12:00:00.000Z",
+        "download_url": f"https://example.com/dl/{gid}",
+        "permanent_url": f"https://example.com/perm/{gid}",
+        "created_by": {"gid": "user1", "name": "Alice"},
+    }
+
+
+def build_export_tree(
+    root: str,
+    teams: list[dict[str, Any]] | None = None,
+    projects: dict[str, list[dict[str, Any]]] | None = None,
+    tasks: dict[tuple[str, str], list[dict[str, Any]]] | None = None,
+    stories: dict[str, list[dict[str, Any]]] | None = None,
+    subtasks: dict[str, list[tuple[dict[str, Any], list[dict[str, Any]]]]] | None = None,
+    attachments: dict[str, list[dict[str, Any]]] | None = None,
+) -> None:
+    """Build a minimal export directory tree.
+
+    Args:
+        root: Temp directory root.
+        teams: List of team dicts.
+        projects: Dict mapping team_gid -> list of project dicts.
+        tasks: Dict mapping (team_gid, project_gid) -> list of task dicts.
+        stories: Dict mapping task_gid -> list of story dicts.
+        subtasks: Dict mapping task_gid -> list of (subtask_dict, subtask_stories) pairs.
+        attachments: Dict mapping task_gid -> list of attachment dicts.
+    """
+    teams = teams or [{"gid": "team1", "name": "Engineering"}]
+    projects = projects or {"team1": [{"gid": "proj1", "name": "Project One"}]}
+    tasks = tasks or {}
+    stories = stories or {}
+    subtasks = subtasks or {}
+    attachments = attachments or {}
+
+    root_path = Path(root)
+    write_json(root_path / "teams.json", teams)
+
+    for team in teams:
+        tgid = team["gid"]
+        team_dir = root_path / "teams" / tgid
+        write_json(team_dir / "projects.json", projects.get(tgid, []))
+
+        for proj in projects.get(tgid, []):
+            pgid = proj["gid"]
+            proj_dir = team_dir / "projects" / pgid
+
+            # tasks.json (summary list)
+            task_list = tasks.get((tgid, pgid), [])
+            write_json(
+                proj_dir / "tasks.json",
+                [{"gid": t["gid"], "name": t["name"]} for t in task_list],
+            )
+
+            # Individual task directories
+            for task in task_list:
+                task_dir = proj_dir / "tasks" / task["gid"]
+                write_json(task_dir / "task.json", task)
+
+                # Stories
+                if task["gid"] in stories:
+                    write_json(task_dir / "stories.json", stories[task["gid"]])
+
+                # Attachments (individual files in attachments/ dir)
+                if task["gid"] in attachments:
+                    att_dir = task_dir / "attachments"
+                    for att in attachments[task["gid"]]:
+                        write_json(att_dir / att["gid"], att)
+
+                # Subtasks
+                if task["gid"] in subtasks:
+                    for sub, sub_stories in subtasks[task["gid"]]:
+                        sub_dir = task_dir / "subtasks" / sub["gid"]
+                        write_json(sub_dir / "subtask.json", sub)
+                        if sub_stories:
+                            write_json(sub_dir / "stories.json", sub_stories)

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -192,10 +192,20 @@ class TestFormatList:
     def test_wraps_with_next_page_when_more(self) -> None:
         query_result = {
             "results": [
-                {"gid": "t1", "name": "Task 1", "permalink_url": "https://example.com/t1",
-                 "notes": "x", "completed": 0},
-                {"gid": "t2", "name": "Task 2", "permalink_url": "https://example.com/t2",
-                 "notes": "y", "completed": 0},
+                {
+                    "gid": "t1",
+                    "name": "Task 1",
+                    "permalink_url": "https://example.com/t1",
+                    "notes": "x",
+                    "completed": 0,
+                },
+                {
+                    "gid": "t2",
+                    "name": "Task 2",
+                    "permalink_url": "https://example.com/t2",
+                    "notes": "y",
+                    "completed": 0,
+                },
             ],
             "count": 2,
             "total": 5,
@@ -214,8 +224,12 @@ class TestFormatList:
     def test_next_page_null_on_last_page(self) -> None:
         query_result = {
             "results": [
-                {"gid": "t1", "name": "Task 1", "permalink_url": "https://example.com/t1",
-                 "completed": 0},
+                {
+                    "gid": "t1",
+                    "name": "Task 1",
+                    "permalink_url": "https://example.com/t1",
+                    "completed": 0,
+                },
             ],
             "count": 1,
             "total": 1,
@@ -259,10 +273,18 @@ class TestFormatSearchObjects:
     def test_wraps_results_in_data(self) -> None:
         query_result = {
             "results": [
-                {"gid": "t1", "name": "Task 1", "permalink_url": "https://example.com/t1",
-                 "completed": 0},
-                {"gid": "t2", "name": "Task 2", "permalink_url": "https://example.com/t2",
-                 "completed": 0},
+                {
+                    "gid": "t1",
+                    "name": "Task 1",
+                    "permalink_url": "https://example.com/t1",
+                    "completed": 0,
+                },
+                {
+                    "gid": "t2",
+                    "name": "Task 2",
+                    "permalink_url": "https://example.com/t2",
+                    "completed": 0,
+                },
             ],
             "count": 2,
         }

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,0 +1,349 @@
+"""Tests for asana_exporter.mcp.formatters."""
+
+from asana_exporter.mcp.formatters import (
+    format_list,
+    format_project,
+    format_search_objects,
+    format_single,
+    format_task,
+    format_user,
+    parse_opt_fields,
+)
+
+
+class TestFormatTaskCompact:
+    def test_compact_returns_only_gid_name_permalink(self) -> None:
+        row = {
+            "gid": "t1",
+            "name": "Fix login bug",
+            "permalink_url": "https://app.asana.com/0/0/t1",
+            "notes": "Login fails on mobile",
+            "assignee_gid": "u1",
+            "assignee_name": "Alice",
+            "completed": 0,
+            "custom_fields": [],
+            "followers": [],
+        }
+        result = format_task(row, opt_fields=None)
+        assert result == {
+            "gid": "t1",
+            "name": "Fix login bug",
+            "permalink_url": "https://app.asana.com/0/0/t1",
+        }
+
+
+class TestFormatProjectCompact:
+    def test_compact_returns_only_gid_name_permalink(self) -> None:
+        row = {
+            "gid": "p1",
+            "name": "Backend API",
+            "permalink_url": "https://app.asana.com/0/0/p1",
+            "team_gid": "team1",
+            "archived": 0,
+            "description": "Project description",
+            "owner_gid": "u1",
+        }
+        result = format_project(row, opt_fields=None)
+        assert result == {
+            "gid": "p1",
+            "name": "Backend API",
+            "permalink_url": "https://app.asana.com/0/0/p1",
+        }
+
+
+class TestFormatProjectOptFields:
+    def test_builds_team_nested_object(self) -> None:
+        row = {
+            "gid": "p1",
+            "name": "Backend API",
+            "permalink_url": "https://app.asana.com/0/0/p1",
+            "team_gid": "team1",
+            "team_name": "Engineering",
+            "archived": 0,
+        }
+        result = format_project(row, opt_fields={"team"})
+        assert result["team"] == {"gid": "team1", "name": "Engineering"}
+
+    def test_coerces_archived_to_bool(self) -> None:
+        row = {
+            "gid": "p1",
+            "name": "Backend API",
+            "permalink_url": "https://app.asana.com/0/0/p1",
+            "archived": 0,
+        }
+        result = format_project(row, opt_fields={"archived"})
+        assert result["archived"] is False
+
+        row["archived"] = 1
+        result = format_project(row, opt_fields={"archived"})
+        assert result["archived"] is True
+
+
+class TestFormatUserCompact:
+    def test_compact_returns_only_gid_name_permalink(self) -> None:
+        row = {
+            "gid": "u1",
+            "name": "Alice",
+            "email": "alice@example.com",
+        }
+        result = format_user(row, opt_fields=None)
+        assert result == {
+            "gid": "u1",
+            "name": "Alice",
+            "permalink_url": None,
+        }
+
+
+class TestFormatTaskOptFields:
+    def test_includes_requested_scalar_fields(self) -> None:
+        row = {
+            "gid": "t1",
+            "name": "Fix login bug",
+            "permalink_url": "https://app.asana.com/0/0/t1",
+            "notes": "Login fails on mobile",
+            "due_on": "2024-02-01",
+            "assignee_gid": "u1",
+            "assignee_name": "Alice",
+            "completed": 0,
+            "custom_fields": [],
+            "followers": [],
+        }
+        result = format_task(row, opt_fields={"notes", "due_on"})
+        assert result == {
+            "gid": "t1",
+            "name": "Fix login bug",
+            "permalink_url": "https://app.asana.com/0/0/t1",
+            "notes": "Login fails on mobile",
+            "due_on": "2024-02-01",
+        }
+
+    def test_coerces_completed_to_bool(self) -> None:
+        row = {
+            "gid": "t1",
+            "name": "Fix login bug",
+            "permalink_url": "https://app.asana.com/0/0/t1",
+            "completed": 1,
+        }
+        result = format_task(row, opt_fields={"completed"})
+        assert result["completed"] is True
+
+        row["completed"] = 0
+        result = format_task(row, opt_fields={"completed"})
+        assert result["completed"] is False
+
+    def test_builds_assignee_nested_object(self) -> None:
+        row = {
+            "gid": "t1",
+            "name": "Fix login bug",
+            "permalink_url": "https://app.asana.com/0/0/t1",
+            "assignee_gid": "u1",
+            "assignee_name": "Alice",
+        }
+        result = format_task(row, opt_fields={"assignee"})
+        assert result["assignee"] == {"gid": "u1", "name": "Alice"}
+
+    def test_includes_num_subtasks(self) -> None:
+        row = {
+            "gid": "t1",
+            "name": "Fix login bug",
+            "permalink_url": "https://app.asana.com/0/0/t1",
+            "num_subtasks": 3,
+        }
+        result = format_task(row, opt_fields={"num_subtasks"})
+        assert result["num_subtasks"] == 3
+
+    def test_builds_parent_nested_object_with_name(self) -> None:
+        row = {
+            "gid": "t1",
+            "name": "Fix login bug",
+            "permalink_url": "https://app.asana.com/0/0/t1",
+            "parent_gid": "t0",
+            "parent_name": "Parent task",
+        }
+        result = format_task(row, opt_fields={"parent.name"})
+        assert result["parent"] == {"gid": "t0", "name": "Parent task"}
+
+    def test_null_assignee(self) -> None:
+        row = {
+            "gid": "t1",
+            "name": "Fix login bug",
+            "permalink_url": "https://app.asana.com/0/0/t1",
+            "assignee_gid": None,
+            "assignee_name": "",
+        }
+        result = format_task(row, opt_fields={"assignee"})
+        assert result["assignee"] is None
+
+
+class TestParseOptFields:
+    def test_returns_none_when_none(self) -> None:
+        assert parse_opt_fields(None) is None
+
+    def test_parses_comma_separated_fields(self) -> None:
+        result = parse_opt_fields("name,completed,assignee.name,due_on")
+        assert result == {"name", "completed", "assignee.name", "due_on"}
+
+    def test_strips_whitespace(self) -> None:
+        result = parse_opt_fields(" name , due_on ")
+        assert result == {"name", "due_on"}
+
+
+class TestFormatList:
+    def test_wraps_with_next_page_when_more(self) -> None:
+        query_result = {
+            "results": [
+                {"gid": "t1", "name": "Task 1", "permalink_url": "https://example.com/t1",
+                 "notes": "x", "completed": 0},
+                {"gid": "t2", "name": "Task 2", "permalink_url": "https://example.com/t2",
+                 "notes": "y", "completed": 0},
+            ],
+            "count": 2,
+            "total": 5,
+            "has_more": True,
+            "next_offset": 2,
+        }
+        result = format_list(query_result, "task", opt_fields=None)
+        assert result == {
+            "data": [
+                {"gid": "t1", "name": "Task 1", "permalink_url": "https://example.com/t1"},
+                {"gid": "t2", "name": "Task 2", "permalink_url": "https://example.com/t2"},
+            ],
+            "next_page": {"offset": "2"},
+        }
+
+    def test_next_page_null_on_last_page(self) -> None:
+        query_result = {
+            "results": [
+                {"gid": "t1", "name": "Task 1", "permalink_url": "https://example.com/t1",
+                 "completed": 0},
+            ],
+            "count": 1,
+            "total": 1,
+            "has_more": False,
+        }
+        result = format_list(query_result, "task", opt_fields=None)
+        assert result["next_page"] is None
+
+
+class TestFormatSingle:
+    def test_wraps_in_data_envelope(self) -> None:
+        row = {
+            "gid": "t1",
+            "name": "Fix login bug",
+            "permalink_url": "https://app.asana.com/0/0/t1",
+            "notes": "x",
+        }
+        result = format_single(row, "task", opt_fields=None)
+        assert result == {
+            "data": {
+                "gid": "t1",
+                "name": "Fix login bug",
+                "permalink_url": "https://app.asana.com/0/0/t1",
+            }
+        }
+
+    def test_passes_opt_fields_through(self) -> None:
+        row = {
+            "gid": "t1",
+            "name": "Fix login bug",
+            "permalink_url": "https://app.asana.com/0/0/t1",
+            "notes": "Login fails",
+            "completed": 1,
+        }
+        result = format_single(row, "task", opt_fields="notes,completed")
+        assert result["data"]["notes"] == "Login fails"
+        assert result["data"]["completed"] is True
+
+
+class TestFormatSearchObjects:
+    def test_wraps_results_in_data(self) -> None:
+        query_result = {
+            "results": [
+                {"gid": "t1", "name": "Task 1", "permalink_url": "https://example.com/t1",
+                 "completed": 0},
+                {"gid": "t2", "name": "Task 2", "permalink_url": "https://example.com/t2",
+                 "completed": 0},
+            ],
+            "count": 2,
+        }
+        result = format_search_objects(query_result, "task", opt_fields=None)
+        assert result == {
+            "data": [
+                {"gid": "t1", "name": "Task 1", "permalink_url": "https://example.com/t1"},
+                {"gid": "t2", "name": "Task 2", "permalink_url": "https://example.com/t2"},
+            ]
+        }
+
+
+class TestFormatTaskTags:
+    def test_tags_formatted_as_name_objects(self) -> None:
+        row = {
+            "gid": "t1",
+            "name": "Fix login bug",
+            "permalink_url": "https://app.asana.com/0/0/t1",
+            "tags": ["urgent", "bug"],
+        }
+        result = format_task(row, opt_fields={"tags"})
+        assert result["tags"] == [{"name": "urgent"}, {"name": "bug"}]
+
+    def test_projects_from_row(self) -> None:
+        row = {
+            "gid": "t1",
+            "name": "Fix login bug",
+            "permalink_url": "https://app.asana.com/0/0/t1",
+            "project_gid": "p1",
+            "project_name": "Backend API",
+        }
+        result = format_task(row, opt_fields={"projects"})
+        assert result["projects"] == [{"gid": "p1", "name": "Backend API"}]
+
+    def test_empty_tags(self) -> None:
+        row = {
+            "gid": "t1",
+            "name": "Fix login bug",
+            "permalink_url": "https://app.asana.com/0/0/t1",
+            "tags": [],
+        }
+        result = format_task(row, opt_fields={"tags"})
+        assert result["tags"] == []
+
+
+class TestFormatTaskStories:
+    def test_stories_passed_through_when_present(self) -> None:
+        stories = [
+            {
+                "gid": "s1",
+                "text": "comment text",
+                "type": "comment",
+                "created_by": {"name": "Alice"},
+            },
+        ]
+        row = {
+            "gid": "t1",
+            "name": "Fix login bug",
+            "permalink_url": "https://app.asana.com/0/0/t1",
+            "stories": stories,
+        }
+        result = format_task(row, opt_fields={"notes"})
+        assert result["stories"] == stories
+
+    def test_snippet_passed_through_when_present(self) -> None:
+        row = {
+            "gid": "t1",
+            "name": "Fix login bug",
+            "permalink_url": "https://app.asana.com/0/0/t1",
+            "snippet": "Found **login** issue in...",
+        }
+        result = format_task(row, opt_fields={"notes"})
+        assert result["snippet"] == "Found **login** issue in..."
+
+    def test_stories_passed_through_in_compact_mode(self) -> None:
+        stories = [{"gid": "s1", "text": "hello"}]
+        row = {
+            "gid": "t1",
+            "name": "Fix login bug",
+            "permalink_url": "https://app.asana.com/0/0/t1",
+            "stories": stories,
+        }
+        result = format_task(row, opt_fields=None)
+        assert result["stories"] == stories

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,0 +1,185 @@
+"""Tests for asana_exporter.database.queries."""
+
+import sqlite3
+
+from asana_exporter.database.queries import (
+    get_project,
+    get_projects,
+    get_task,
+    get_tasks,
+    get_user,
+    search_objects,
+    search_tasks,
+)
+
+
+class TestGetUser:
+    def test_get_user_by_gid_returns_user(self, populated_db: sqlite3.Connection) -> None:
+        result = get_user(populated_db, user_gid="user1")
+        assert result["gid"] == "user1"
+        assert result["name"] == "Alice"
+
+    def test_get_user_not_found_returns_error(self, populated_db: sqlite3.Connection) -> None:
+        result = get_user(populated_db, user_gid="nonexistent")
+        assert "error" in result
+
+    def test_get_user_by_email_returns_user(self, populated_db: sqlite3.Connection) -> None:
+        result = get_user(populated_db, email="alice@example.com")
+        assert result["gid"] == "user1"
+        assert result["name"] == "Alice"
+
+
+class TestGetProject:
+    def test_get_project_returns_project_with_sections(
+        self, populated_db: sqlite3.Connection
+    ) -> None:
+        result = get_project(populated_db, project_gid="proj1")
+        assert result["name"] == "Backend API"
+        assert "sections" in result
+        assert len(result["sections"]) >= 2
+
+    def test_get_project_not_found_returns_error(
+        self, populated_db: sqlite3.Connection
+    ) -> None:
+        result = get_project(populated_db, project_gid="nonexistent")
+        assert "error" in result
+
+
+class TestGetProjects:
+    def test_get_projects_returns_all_projects(
+        self, populated_db: sqlite3.Connection
+    ) -> None:
+        result = get_projects(populated_db)
+        assert result["total"] == 3
+        assert result["count"] == 3
+
+    def test_get_projects_filters_by_team(self, populated_db: sqlite3.Connection) -> None:
+        result = get_projects(populated_db, team_gid="team1")
+        assert result["total"] == 2
+        assert all(p["team_gid"] == "team1" for p in result["results"])
+
+    def test_get_projects_filters_by_archived(self, populated_db: sqlite3.Connection) -> None:
+        result = get_projects(populated_db, archived=False)
+        assert result["total"] == 3  # None are explicitly archived in our fixture
+
+    def test_get_projects_pagination(self, populated_db: sqlite3.Connection) -> None:
+        result = get_projects(populated_db, limit=2, offset=0)
+        assert result["count"] == 2
+        assert result["total"] == 3
+        assert result["has_more"] is True
+        assert result["next_offset"] == 2
+
+        result2 = get_projects(populated_db, limit=2, offset=2)
+        assert result2["count"] == 1
+        assert result2["has_more"] is False
+
+
+class TestGetTask:
+    def test_get_task_returns_task_details(self, populated_db: sqlite3.Connection) -> None:
+        result = get_task(populated_db, task_gid="t1")
+        assert result["name"] == "Fix login bug"
+        assert result["assignee_name"] == "Alice"
+        assert isinstance(result["tags"], list)
+        assert "raw_json" not in result
+
+    def test_get_task_not_found_returns_error(self, populated_db: sqlite3.Connection) -> None:
+        result = get_task(populated_db, task_gid="nonexistent")
+        assert "error" in result
+
+    def test_get_task_includes_subtasks(self, populated_db: sqlite3.Connection) -> None:
+        result = get_task(populated_db, task_gid="t1", include_subtasks=True)
+        assert len(result["subtasks"]) == 1
+        assert result["subtasks"][0]["name"] == "Reproduce on Android"
+
+    def test_get_task_includes_stories(self, populated_db: sqlite3.Connection) -> None:
+        result = get_task(populated_db, task_gid="t1", include_stories=True)
+        assert len(result["stories"]) == 1
+        assert "root cause" in result["stories"][0]["text"]
+
+
+class TestGetTasks:
+    def test_get_tasks_by_project(self, populated_db: sqlite3.Connection) -> None:
+        result = get_tasks(populated_db, project_gid="proj1")
+        assert result["total"] >= 4  # t1, t2, t3, t6 (+ subtask st1)
+        assert all(t["project_gid"] == "proj1" for t in result["results"])
+
+    def test_get_tasks_filters_by_completed(self, populated_db: sqlite3.Connection) -> None:
+        result = get_tasks(populated_db, project_gid="proj1", completed=True)
+        assert result["total"] >= 1
+        assert all(t["completed"] for t in result["results"])
+
+    def test_get_tasks_filters_by_assignee(self, populated_db: sqlite3.Connection) -> None:
+        result = get_tasks(populated_db, assignee_gid="user1")
+        assert result["total"] >= 1
+        assert all(t["assignee_gid"] == "user1" for t in result["results"])
+
+    def test_get_tasks_pagination(self, populated_db: sqlite3.Connection) -> None:
+        result = get_tasks(populated_db, project_gid="proj1", limit=2, offset=0)
+        assert result["count"] == 2
+        assert result["has_more"] is True
+
+
+class TestSearchTasks:
+    def test_search_tasks_finds_by_name(self, populated_db: sqlite3.Connection) -> None:
+        result = search_tasks(populated_db, query="login")
+        assert result["count"] >= 1
+        assert any(r["name"] == "Fix login bug" for r in result["results"])
+
+    def test_search_tasks_filters_by_project(self, populated_db: sqlite3.Connection) -> None:
+        result = search_tasks(populated_db, query="dashboard", project_gid="proj2")
+        assert result["count"] >= 1
+        assert all(r["project_gid"] == "proj2" for r in result["results"])
+
+    def test_search_tasks_filters_by_completed(self, populated_db: sqlite3.Connection) -> None:
+        result = search_tasks(populated_db, query="API", completed=True)
+        assert result["count"] >= 1
+        assert all(r["completed"] for r in result["results"])
+
+    def test_search_tasks_finds_by_notes(self, populated_db: sqlite3.Connection) -> None:
+        result = search_tasks(populated_db, query="mobile")
+        assert result["count"] >= 1
+        assert any(r["name"] == "Fix login bug" for r in result["results"])
+
+    def test_search_tasks_holistic_finds_in_comments(
+        self, populated_db: sqlite3.Connection
+    ) -> None:
+        result = search_tasks(populated_db, query="root cause", use_holistic=True)
+        assert result["count"] >= 1
+        # t1 found because its comment mentions "root cause"
+        assert any(r["gid"] == "t1" for r in result["results"])
+
+    def test_search_tasks_empty_query_returns_error(
+        self, populated_db: sqlite3.Connection
+    ) -> None:
+        result = search_tasks(populated_db, query="")
+        assert "error" in result
+
+    def test_search_tasks_pagination(self, populated_db: sqlite3.Connection) -> None:
+        result = search_tasks(populated_db, query="API", limit=1, offset=0)
+        assert result["count"] == 1
+        assert result["has_more"] is True
+
+
+class TestSearchObjects:
+    def test_search_objects_finds_projects(self, populated_db: sqlite3.Connection) -> None:
+        result = search_objects(populated_db, query="Backend", resource_type="project")
+        assert result["count"] >= 1
+        assert any(r["name"] == "Backend API" for r in result["results"])
+
+    def test_search_objects_finds_users(self, populated_db: sqlite3.Connection) -> None:
+        result = search_objects(populated_db, query="Alice", resource_type="user")
+        assert result["count"] >= 1
+        assert any(r["name"] == "Alice" for r in result["results"])
+
+    def test_search_objects_invalid_type_returns_error(
+        self, populated_db: sqlite3.Connection
+    ) -> None:
+        result = search_objects(populated_db, query="test", resource_type="invalid")
+        assert "error" in result
+
+
+class TestMcpServer:
+    def test_mcp_server_creates_without_error(self) -> None:
+        from asana_exporter.mcp.server import mcp_server
+
+        assert mcp_server.name == "asana-archive"

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -39,17 +39,13 @@ class TestGetProject:
         assert "sections" in result
         assert len(result["sections"]) >= 2
 
-    def test_get_project_not_found_returns_error(
-        self, populated_db: sqlite3.Connection
-    ) -> None:
+    def test_get_project_not_found_returns_error(self, populated_db: sqlite3.Connection) -> None:
         result = get_project(populated_db, project_gid="nonexistent")
         assert "error" in result
 
 
 class TestGetProjects:
-    def test_get_projects_returns_all_projects(
-        self, populated_db: sqlite3.Connection
-    ) -> None:
+    def test_get_projects_returns_all_projects(self, populated_db: sqlite3.Connection) -> None:
         result = get_projects(populated_db)
         assert result["total"] == 3
         assert result["count"] == 3
@@ -157,9 +153,7 @@ class TestSearchTasks:
         # t1 found because its comment mentions "root cause"
         assert any(r["gid"] == "t1" for r in result["results"])
 
-    def test_search_tasks_finds_underscored_terms(
-        self, populated_db: sqlite3.Connection
-    ) -> None:
+    def test_search_tasks_finds_underscored_terms(self, populated_db: sqlite3.Connection) -> None:
         result = search_tasks(populated_db, query="user_id")
         assert result["count"] >= 1
         assert any(r["name"] == "Rename user_id to account_id" for r in result["results"])
@@ -167,9 +161,7 @@ class TestSearchTasks:
     def test_holistic_search_snippet_shows_comment_match(
         self, populated_db: sqlite3.Connection
     ) -> None:
-        result = search_tasks(
-            populated_db, query="session token", use_holistic=True
-        )
+        result = search_tasks(populated_db, query="session token", use_holistic=True)
         assert result["count"] >= 1
         match = next(r for r in result["results"] if r["gid"] == "t1")
         # Snippet should come from the comment, not the task name
@@ -180,16 +172,12 @@ class TestSearchTasks:
     ) -> None:
         # "login" matches notes, "session token" matches comment.
         # Comment has more highlighted terms, so should be preferred.
-        result = search_tasks(
-            populated_db, query="login session token", use_holistic=True
-        )
+        result = search_tasks(populated_db, query="login session token", use_holistic=True)
         assert result["count"] >= 1
         match = next(r for r in result["results"] if r["gid"] == "t1")
         assert "[comment]" in match["snippet"]
 
-    def test_search_tasks_empty_query_returns_error(
-        self, populated_db: sqlite3.Connection
-    ) -> None:
+    def test_search_tasks_empty_query_returns_error(self, populated_db: sqlite3.Connection) -> None:
         result = search_tasks(populated_db, query="")
         assert "error" in result
 

--- a/uv.lock
+++ b/uv.lock
@@ -54,6 +54,7 @@ dependencies = [
     { name = "asana" },
     { name = "loguru" },
     { name = "mcp", extra = ["cli"] },
+    { name = "pydantic" },
 ]
 
 [package.dev-dependencies]
@@ -76,6 +77,7 @@ requires-dist = [
     { name = "asana" },
     { name = "loguru", specifier = ">=0.7.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.9.0" },
+    { name = "pydantic", specifier = ">=2.12.5" },
 ]
 
 [package.metadata.requires-dev]

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,36 @@ revision = 3
 requires-python = ">=3.13"
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
 name = "asana"
 version = "5.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -23,6 +53,7 @@ source = { editable = "." }
 dependencies = [
     { name = "asana" },
     { name = "loguru" },
+    { name = "mcp", extra = ["cli"] },
 ]
 
 [package.dev-dependencies]
@@ -44,6 +75,7 @@ dev = [
 requires-dist = [
     { name = "asana" },
     { name = "loguru", specifier = ">=0.7.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.9.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -77,6 +109,51 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -170,6 +247,59 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "46.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/04/ee2a9e8542e4fa2773b81771ff8349ff19cdd56b7258a0cc442639052edb/cryptography-46.0.5.tar.gz", hash = "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d", size = 750064, upload-time = "2026-02-10T19:18:38.255Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/81/b0bb27f2ba931a65409c6b8a8b358a7f03c0e46eceacddff55f7c84b1f3b/cryptography-46.0.5-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:351695ada9ea9618b3500b490ad54c739860883df6c1f555e088eaf25b1bbaad", size = 7176289, upload-time = "2026-02-10T19:17:08.274Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/9e/6b4397a3e3d15123de3b1806ef342522393d50736c13b20ec4c9ea6693a6/cryptography-46.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c18ff11e86df2e28854939acde2d003f7984f721eba450b56a200ad90eeb0e6b", size = 4275637, upload-time = "2026-02-10T19:17:10.53Z" },
+    { url = "https://files.pythonhosted.org/packages/63/e7/471ab61099a3920b0c77852ea3f0ea611c9702f651600397ac567848b897/cryptography-46.0.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d7e3d356b8cd4ea5aff04f129d5f66ebdc7b6f8eae802b93739ed520c47c79b", size = 4424742, upload-time = "2026-02-10T19:17:12.388Z" },
+    { url = "https://files.pythonhosted.org/packages/37/53/a18500f270342d66bf7e4d9f091114e31e5ee9e7375a5aba2e85a91e0044/cryptography-46.0.5-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:50bfb6925eff619c9c023b967d5b77a54e04256c4281b0e21336a130cd7fc263", size = 4277528, upload-time = "2026-02-10T19:17:13.853Z" },
+    { url = "https://files.pythonhosted.org/packages/22/29/c2e812ebc38c57b40e7c583895e73c8c5adb4d1e4a0cc4c5a4fdab2b1acc/cryptography-46.0.5-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:803812e111e75d1aa73690d2facc295eaefd4439be1023fefc4995eaea2af90d", size = 4947993, upload-time = "2026-02-10T19:17:15.618Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/e7/237155ae19a9023de7e30ec64e5d99a9431a567407ac21170a046d22a5a3/cryptography-46.0.5-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ee190460e2fbe447175cda91b88b84ae8322a104fc27766ad09428754a618ed", size = 4456855, upload-time = "2026-02-10T19:17:17.221Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/87/fc628a7ad85b81206738abbd213b07702bcbdada1dd43f72236ef3cffbb5/cryptography-46.0.5-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:f145bba11b878005c496e93e257c1e88f154d278d2638e6450d17e0f31e558d2", size = 3984635, upload-time = "2026-02-10T19:17:18.792Z" },
+    { url = "https://files.pythonhosted.org/packages/84/29/65b55622bde135aedf4565dc509d99b560ee4095e56989e815f8fd2aa910/cryptography-46.0.5-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e9251e3be159d1020c4030bd2e5f84d6a43fe54b6c19c12f51cde9542a2817b2", size = 4277038, upload-time = "2026-02-10T19:17:20.256Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/45e76c68d7311432741faf1fbf7fac8a196a0a735ca21f504c75d37e2558/cryptography-46.0.5-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:47fb8a66058b80e509c47118ef8a75d14c455e81ac369050f20ba0d23e77fee0", size = 4912181, upload-time = "2026-02-10T19:17:21.825Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/1a/c1ba8fead184d6e3d5afcf03d569acac5ad063f3ac9fb7258af158f7e378/cryptography-46.0.5-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4c3341037c136030cb46e4b1e17b7418ea4cbd9dd207e4a6f3b2b24e0d4ac731", size = 4456482, upload-time = "2026-02-10T19:17:25.133Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/e5/3fb22e37f66827ced3b902cf895e6a6bc1d095b5b26be26bd13c441fdf19/cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:890bcb4abd5a2d3f852196437129eb3667d62630333aacc13dfd470fad3aaa82", size = 4405497, upload-time = "2026-02-10T19:17:26.66Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/df/9d58bb32b1121a8a2f27383fabae4d63080c7ca60b9b5c88be742be04ee7/cryptography-46.0.5-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80a8d7bfdf38f87ca30a5391c0c9ce4ed2926918e017c29ddf643d0ed2778ea1", size = 4667819, upload-time = "2026-02-10T19:17:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ed/325d2a490c5e94038cdb0117da9397ece1f11201f425c4e9c57fe5b9f08b/cryptography-46.0.5-cp311-abi3-win32.whl", hash = "sha256:60ee7e19e95104d4c03871d7d7dfb3d22ef8a9b9c6778c94e1c8fcc8365afd48", size = 3028230, upload-time = "2026-02-10T19:17:30.518Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5a/ac0f49e48063ab4255d9e3b79f5def51697fce1a95ea1370f03dc9db76f6/cryptography-46.0.5-cp311-abi3-win_amd64.whl", hash = "sha256:38946c54b16c885c72c4f59846be9743d699eee2b69b6988e0a00a01f46a61a4", size = 3480909, upload-time = "2026-02-10T19:17:32.083Z" },
+    { url = "https://files.pythonhosted.org/packages/00/13/3d278bfa7a15a96b9dc22db5a12ad1e48a9eb3d40e1827ef66a5df75d0d0/cryptography-46.0.5-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:94a76daa32eb78d61339aff7952ea819b1734b46f73646a07decb40e5b3448e2", size = 7119287, upload-time = "2026-02-10T19:17:33.801Z" },
+    { url = "https://files.pythonhosted.org/packages/67/c8/581a6702e14f0898a0848105cbefd20c058099e2c2d22ef4e476dfec75d7/cryptography-46.0.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5be7bf2fb40769e05739dd0046e7b26f9d4670badc7b032d6ce4db64dddc0678", size = 4265728, upload-time = "2026-02-10T19:17:35.569Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/4a/ba1a65ce8fc65435e5a849558379896c957870dd64fecea97b1ad5f46a37/cryptography-46.0.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe346b143ff9685e40192a4960938545c699054ba11d4f9029f94751e3f71d87", size = 4408287, upload-time = "2026-02-10T19:17:36.938Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/67/8ffdbf7b65ed1ac224d1c2df3943553766914a8ca718747ee3871da6107e/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c69fd885df7d089548a42d5ec05be26050ebcd2283d89b3d30676eb32ff87dee", size = 4270291, upload-time = "2026-02-10T19:17:38.748Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e5/f52377ee93bc2f2bba55a41a886fd208c15276ffbd2569f2ddc89d50e2c5/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:8293f3dea7fc929ef7240796ba231413afa7b68ce38fd21da2995549f5961981", size = 4927539, upload-time = "2026-02-10T19:17:40.241Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/02/cfe39181b02419bbbbcf3abdd16c1c5c8541f03ca8bda240debc467d5a12/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1abfdb89b41c3be0365328a410baa9df3ff8a9110fb75e7b52e66803ddabc9a9", size = 4442199, upload-time = "2026-02-10T19:17:41.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/96/2fcaeb4873e536cf71421a388a6c11b5bc846e986b2b069c79363dc1648e/cryptography-46.0.5-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:d66e421495fdb797610a08f43b05269e0a5ea7f5e652a89bfd5a7d3c1dee3648", size = 3960131, upload-time = "2026-02-10T19:17:43.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/d2/b27631f401ddd644e94c5cf33c9a4069f72011821cf3dc7309546b0642a0/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:4e817a8920bfbcff8940ecfd60f23d01836408242b30f1a708d93198393a80b4", size = 4270072, upload-time = "2026-02-10T19:17:45.481Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/a7/60d32b0370dae0b4ebe55ffa10e8599a2a59935b5ece1b9f06edb73abdeb/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:68f68d13f2e1cb95163fa3b4db4bf9a159a418f5f6e7242564fc75fcae667fd0", size = 4892170, upload-time = "2026-02-10T19:17:46.997Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/b9/cf73ddf8ef1164330eb0b199a589103c363afa0cf794218c24d524a58eab/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a3d1fae9863299076f05cb8a778c467578262fae09f9dc0ee9b12eb4268ce663", size = 4441741, upload-time = "2026-02-10T19:17:48.661Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/eee00b28c84c726fe8fa0158c65afe312d9c3b78d9d01daf700f1f6e37ff/cryptography-46.0.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4143987a42a2397f2fc3b4d7e3a7d313fbe684f67ff443999e803dd75a76826", size = 4396728, upload-time = "2026-02-10T19:17:50.058Z" },
+    { url = "https://files.pythonhosted.org/packages/65/f4/6bc1a9ed5aef7145045114b75b77c2a8261b4d38717bd8dea111a63c3442/cryptography-46.0.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7d731d4b107030987fd61a7f8ab512b25b53cef8f233a97379ede116f30eb67d", size = 4652001, upload-time = "2026-02-10T19:17:51.54Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ef/5d00ef966ddd71ac2e6951d278884a84a40ffbd88948ef0e294b214ae9e4/cryptography-46.0.5-cp314-cp314t-win32.whl", hash = "sha256:c3bcce8521d785d510b2aad26ae2c966092b7daa8f45dd8f44734a104dc0bc1a", size = 3003637, upload-time = "2026-02-10T19:17:52.997Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/f3f4160123da6d098db78350fdfd9705057aad21de7388eacb2401dceab9/cryptography-46.0.5-cp314-cp314t-win_amd64.whl", hash = "sha256:4d8ae8659ab18c65ced284993c2265910f6c9e650189d4e3f68445ef82a810e4", size = 3469487, upload-time = "2026-02-10T19:17:54.549Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/fa/a66aa722105ad6a458bebd64086ca2b72cdd361fed31763d20390f6f1389/cryptography-46.0.5-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:4108d4c09fbbf2789d0c926eb4152ae1760d5a2d97612b92d508d96c861e4d31", size = 7170514, upload-time = "2026-02-10T19:17:56.267Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/04/c85bdeab78c8bc77b701bf0d9bdcf514c044e18a46dcff330df5448631b0/cryptography-46.0.5-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1f30a86d2757199cb2d56e48cce14deddf1f9c95f1ef1b64ee91ea43fe2e18", size = 4275349, upload-time = "2026-02-10T19:17:58.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/32/9b87132a2f91ee7f5223b091dc963055503e9b442c98fc0b8a5ca765fab0/cryptography-46.0.5-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:039917b0dc418bb9f6edce8a906572d69e74bd330b0b3fea4f79dab7f8ddd235", size = 4420667, upload-time = "2026-02-10T19:18:00.619Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/a6/a7cb7010bec4b7c5692ca6f024150371b295ee1c108bdc1c400e4c44562b/cryptography-46.0.5-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ba2a27ff02f48193fc4daeadf8ad2590516fa3d0adeeb34336b96f7fa64c1e3a", size = 4276980, upload-time = "2026-02-10T19:18:02.379Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/7c/c4f45e0eeff9b91e3f12dbd0e165fcf2a38847288fcfd889deea99fb7b6d/cryptography-46.0.5-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:61aa400dce22cb001a98014f647dc21cda08f7915ceb95df0c9eaf84b4b6af76", size = 4939143, upload-time = "2026-02-10T19:18:03.964Z" },
+    { url = "https://files.pythonhosted.org/packages/37/19/e1b8f964a834eddb44fa1b9a9976f4e414cbb7aa62809b6760c8803d22d1/cryptography-46.0.5-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ce58ba46e1bc2aac4f7d9290223cead56743fa6ab94a5d53292ffaac6a91614", size = 4453674, upload-time = "2026-02-10T19:18:05.588Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ed/db15d3956f65264ca204625597c410d420e26530c4e2943e05a0d2f24d51/cryptography-46.0.5-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:420d0e909050490d04359e7fdb5ed7e667ca5c3c402b809ae2563d7e66a92229", size = 3978801, upload-time = "2026-02-10T19:18:07.167Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e2/df40a31d82df0a70a0daf69791f91dbb70e47644c58581d654879b382d11/cryptography-46.0.5-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:582f5fcd2afa31622f317f80426a027f30dc792e9c80ffee87b993200ea115f1", size = 4276755, upload-time = "2026-02-10T19:18:09.813Z" },
+    { url = "https://files.pythonhosted.org/packages/33/45/726809d1176959f4a896b86907b98ff4391a8aa29c0aaaf9450a8a10630e/cryptography-46.0.5-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:bfd56bb4b37ed4f330b82402f6f435845a5f5648edf1ad497da51a8452d5d62d", size = 4901539, upload-time = "2026-02-10T19:18:11.263Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0f/a3076874e9c88ecb2ecc31382f6e7c21b428ede6f55aafa1aa272613e3cd/cryptography-46.0.5-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:a3d507bb6a513ca96ba84443226af944b0f7f47dcc9a399d110cd6146481d24c", size = 4452794, upload-time = "2026-02-10T19:18:12.914Z" },
+    { url = "https://files.pythonhosted.org/packages/02/ef/ffeb542d3683d24194a38f66ca17c0a4b8bf10631feef44a7ef64e631b1a/cryptography-46.0.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9f16fbdf4da055efb21c22d81b89f155f02ba420558db21288b3d0035bafd5f4", size = 4404160, upload-time = "2026-02-10T19:18:14.375Z" },
+    { url = "https://files.pythonhosted.org/packages/96/93/682d2b43c1d5f1406ed048f377c0fc9fc8f7b0447a478d5c65ab3d3a66eb/cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ced80795227d70549a411a4ab66e8ce307899fad2220ce5ab2f296e687eacde9", size = 4667123, upload-time = "2026-02-10T19:18:15.886Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2d/9c5f2926cb5300a8eefc3f4f0b3f3df39db7f7ce40c8365444c49363cbda/cryptography-46.0.5-cp38-abi3-win32.whl", hash = "sha256:02f547fce831f5096c9a567fd41bc12ca8f11df260959ecc7c3202555cc47a72", size = 3010220, upload-time = "2026-02-10T19:18:17.361Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ef/0c2f4a8e31018a986949d34a01115dd057bf536905dca38897bacd21fac3/cryptography-46.0.5-cp38-abi3-win_amd64.whl", hash = "sha256:556e106ee01aa13484ce9b0239bca667be5004efb0aabbed28d353df86445595", size = 3467050, upload-time = "2026-02-10T19:18:18.899Z" },
+]
+
+[[package]]
 name = "cyclopts"
 version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -242,12 +372,94 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -273,6 +485,37 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+]
+
+[package.optional-dependencies]
+cli = [
+    { name = "python-dotenv" },
+    { name = "typer" },
 ]
 
 [[package]]
@@ -327,12 +570,117 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623", size = 98019, upload-time = "2026-01-30T19:59:55.694Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469", size = 28224, upload-time = "2026-01-30T19:59:54.539Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -391,6 +739,50 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dotenv"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requirements-parser"
 version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -429,6 +821,72 @@ wheels = [
 ]
 
 [[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.4"
 source = { registry = "https://pypi.org/simple" }
@@ -454,12 +912,46 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/8d/00d280c03ffd39aaee0e86ec81e2d3b9253036a0f93f51d10503adef0e65/sse_starlette-3.2.0.tar.gz", hash = "sha256:8127594edfb51abe44eac9c49e59b0b01f1039d0c7461c6fd91d4e03b70da422", size = 27253, upload-time = "2026-01-17T13:11:05.62Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/7f/832f015020844a8b8f7a9cbc103dd76ba8e3875004c41e08440ea3a2b41a/sse_starlette-3.2.0-py3-none-any.whl", hash = "sha256:5876954bd51920fc2cd51baee47a080eb88a37b5b784e615abb0b283f801cdbf", size = 12763, upload-time = "2026-01-17T13:11:03.775Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "0.52.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
 ]
 
 [[package]]
@@ -534,12 +1026,61 @@ wheels = [
 ]
 
 [[package]]
+name = "typer"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add FastMCP-based MCP server exposing the SQLite archive via 7 read-only tools: `search_tasks`, `get_task`, `get_tasks`, `get_project`, `get_projects`, `get_user`, `search_objects`
- Core query functions in `database/queries.py` are frontend-agnostic (take `sqlite3.Connection`), enabling reuse across CLI and MCP
- FTS5 full-text search with per-entity and holistic modes (task + subtasks + comments)
- 22 new tests covering all query functions, plus shared test fixtures extracted to `conftest.py` and `factories.py`

## Test plan

- [x] `uv run --frozen pytest` — 50 tests pass
- [x] `just lint` — all checks pass
- [x] `ASANA_DB_PATH=asana_export/asana.db uv run asana-mcp` — verify server starts on stdio
- [x] Test with MCP inspector or Claude Desktop config

🤖 Generated with [Claude Code](https://claude.com/claude-code)